### PR TITLE
Expand error details by default

### DIFF
--- a/web/_includes/error_box.html
+++ b/web/_includes/error_box.html
@@ -1,5 +1,5 @@
 <div class="error-box">
-<div class="card-header collapsed clearfix" data-toggle="collapse" href="#{{ include.page.slug }}" role="button" aria-expanded="false" aria-controls="collapseExample">
+<div class="card-header clearfix" data-toggle="collapse" href="#{{ include.page.slug }}" role="button" aria-expanded="true" aria-controls="#{{ include.page.slug }}">
     <span class="fa fa-fw fa-chevron-down"></span> <span class="fa fa-fw fa-chevron-right"></span>
     <span class="openssl-code" title="{{ include.page.openssl-code }}">{{ include.page.title }}</span>
     {% if include.page.verify-openssl %}
@@ -18,7 +18,7 @@
         {% include icon.html icon="openssl-book" float="float-right" %}
     {% endif %}
 </div>
-<div class="collapse" id="{{ include.page.slug }}">
+<div class="collapse show" id="{{ include.page.slug }}">
     <div class="card card-body">
         {% if include.page.verify-openssl %}
         <h3>{% include icon.html icon="certificate" %}Example certificate</h3>

--- a/web/assets/js/main.js
+++ b/web/assets/js/main.js
@@ -1,4 +1,11 @@
 $(document).ready(function(){
+    // Collapse error details.
+    $('.collapse.show')
+        .removeClass('show')
+        .siblings('.card-header')
+        .addClass('collapsed');
+
+    // Add shadow under navbar if the page is scrolled already on load.
     $(document).scroll(function() {
         var scrolled = $(this).scrollTop();
         if(scrolled > 50) {


### PR DESCRIPTION
Expand "rolldowns" with error details by default so that they are readable in browsers with JS disabled. Collapse them once the page loads in JavaScript.

We do this by hand, since Bootstrap animates the collapsing, which takes some time, which is undesirable on page load.

Resolves #41