### PR TITLE
Change expiration_days from 30 to 365

### DIFF
--- a/errors/X509_V_ERR_CA_KEY_TOO_SMALL/ca.cfg
+++ b/errors/X509_V_ERR_CA_KEY_TOO_SMALL/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_CA_KEY_TOO_SMALL/endpoint.cfg
+++ b/errors/X509_V_ERR_CA_KEY_TOO_SMALL/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used to sign data (needed
 # in TLS DHE ciphersuites). This is the digitalSignature flag

--- a/errors/X509_V_ERR_CA_MD_TOO_WEAK/ca.cfg
+++ b/errors/X509_V_ERR_CA_MD_TOO_WEAK/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_CA_MD_TOO_WEAK/endpoint.cfg
+++ b/errors/X509_V_ERR_CA_MD_TOO_WEAK/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used to sign data (needed
 # in TLS DHE ciphersuites). This is the digitalSignature flag

--- a/errors/X509_V_ERR_CERT_CHAIN_TOO_LONG/ca.cfg
+++ b/errors/X509_V_ERR_CERT_CHAIN_TOO_LONG/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_CERT_CHAIN_TOO_LONG/endpoint.cfg
+++ b/errors/X509_V_ERR_CERT_CHAIN_TOO_LONG/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used to sign data (needed
 # in TLS DHE ciphersuites). This is the digitalSignature flag

--- a/errors/X509_V_ERR_CERT_CHAIN_TOO_LONG/subca.cfg
+++ b/errors/X509_V_ERR_CERT_CHAIN_TOO_LONG/subca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_CERT_HAS_EXPIRED/ca.cfg
+++ b/errors/X509_V_ERR_CERT_HAS_EXPIRED/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_CERT_NOT_YET_VALID/ca.cfg
+++ b/errors/X509_V_ERR_CERT_NOT_YET_VALID/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_CERT_REJECTED/ca.cfg
+++ b/errors/X509_V_ERR_CERT_REJECTED/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_CERT_REJECTED/endpoint.cfg
+++ b/errors/X509_V_ERR_CERT_REJECTED/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used to sign data (needed
 # in TLS DHE ciphersuites). This is the digitalSignature flag

--- a/errors/X509_V_ERR_CERT_REVOKED/ca.cfg
+++ b/errors/X509_V_ERR_CERT_REVOKED/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_CERT_REVOKED/endpoint.cfg
+++ b/errors/X509_V_ERR_CERT_REVOKED/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used to sign data (needed
 # in TLS DHE ciphersuites). This is the digitalSignature flag

--- a/errors/X509_V_ERR_CERT_SIGNATURE_FAILURE/ca.cfg
+++ b/errors/X509_V_ERR_CERT_SIGNATURE_FAILURE/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_CERT_SIGNATURE_FAILURE/endpoint.cfg
+++ b/errors/X509_V_ERR_CERT_SIGNATURE_FAILURE/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used to sign data (needed
 # in TLS DHE ciphersuites). This is the digitalSignature flag

--- a/errors/X509_V_ERR_CRL_HAS_EXPIRED/ca.cfg
+++ b/errors/X509_V_ERR_CRL_HAS_EXPIRED/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_CRL_HAS_EXPIRED/endpoint.cfg
+++ b/errors/X509_V_ERR_CRL_HAS_EXPIRED/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used to sign data (needed
 # in TLS DHE ciphersuites). This is the digitalSignature flag

--- a/errors/X509_V_ERR_CRL_NOT_YET_VALID/ca.cfg
+++ b/errors/X509_V_ERR_CRL_NOT_YET_VALID/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_CRL_NOT_YET_VALID/endpoint.cfg
+++ b/errors/X509_V_ERR_CRL_NOT_YET_VALID/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used to sign data (needed
 # in TLS DHE ciphersuites). This is the digitalSignature flag

--- a/errors/X509_V_ERR_CRL_SIGNATURE_FAILURE/ca.cfg
+++ b/errors/X509_V_ERR_CRL_SIGNATURE_FAILURE/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_CRL_SIGNATURE_FAILURE/endpoint.cfg
+++ b/errors/X509_V_ERR_CRL_SIGNATURE_FAILURE/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used to sign data (needed
 # in TLS DHE ciphersuites). This is the digitalSignature flag

--- a/errors/X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT/endpoint.cfg
+++ b/errors/X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_EE_KEY_TOO_SMALL/ca.cfg
+++ b/errors/X509_V_ERR_EE_KEY_TOO_SMALL/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_EE_KEY_TOO_SMALL/endpoint.cfg
+++ b/errors/X509_V_ERR_EE_KEY_TOO_SMALL/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used to sign data (needed
 # in TLS DHE ciphersuites). This is the digitalSignature flag

--- a/errors/X509_V_ERR_EMAIL_MISMATCH/ca.cfg
+++ b/errors/X509_V_ERR_EMAIL_MISMATCH/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_EMAIL_MISMATCH/endpoint.cfg
+++ b/errors/X509_V_ERR_EMAIL_MISMATCH/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used to sign data (needed
 # in TLS DHE ciphersuites). This is the digitalSignature flag

--- a/errors/X509_V_ERR_EXCLUDED_VIOLATION/ca.cfg
+++ b/errors/X509_V_ERR_EXCLUDED_VIOLATION/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_EXCLUDED_VIOLATION/endpoint.cfg
+++ b/errors/X509_V_ERR_EXCLUDED_VIOLATION/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used to sign data (needed
 # in TLS DHE ciphersuites). This is the digitalSignature flag

--- a/errors/X509_V_ERR_HOSTNAME_MISMATCH/ca.cfg
+++ b/errors/X509_V_ERR_HOSTNAME_MISMATCH/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_HOSTNAME_MISMATCH/endpoint.cfg
+++ b/errors/X509_V_ERR_HOSTNAME_MISMATCH/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used to sign data (needed
 # in TLS DHE ciphersuites). This is the digitalSignature flag

--- a/errors/X509_V_ERR_INVALID_CA/ca.cfg
+++ b/errors/X509_V_ERR_INVALID_CA/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_INVALID_CA/endpoint.cfg
+++ b/errors/X509_V_ERR_INVALID_CA/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used to sign data (needed
 # in TLS DHE ciphersuites). This is the digitalSignature flag

--- a/errors/X509_V_ERR_INVALID_CA/subca.cfg
+++ b/errors/X509_V_ERR_INVALID_CA/subca.cfg
@@ -12,5 +12,5 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 

--- a/errors/X509_V_ERR_INVALID_NON_CA/ca.cfg
+++ b/errors/X509_V_ERR_INVALID_NON_CA/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_INVALID_NON_CA/endpoint.cfg
+++ b/errors/X509_V_ERR_INVALID_NON_CA/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used to sign data (needed
 # in TLS DHE ciphersuites). This is the digitalSignature flag

--- a/errors/X509_V_ERR_INVALID_PURPOSE/ca.cfg
+++ b/errors/X509_V_ERR_INVALID_PURPOSE/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_INVALID_PURPOSE/endpoint.cfg
+++ b/errors/X509_V_ERR_INVALID_PURPOSE/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used for a TLS client;
 # this sets the id-kp-clientAuth (1.3.6.1.5.5.7.3.2) of

--- a/errors/X509_V_ERR_IP_ADDRESS_MISMATCH/ca.cfg
+++ b/errors/X509_V_ERR_IP_ADDRESS_MISMATCH/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_IP_ADDRESS_MISMATCH/endpoint.cfg
+++ b/errors/X509_V_ERR_IP_ADDRESS_MISMATCH/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used to sign data (needed
 # in TLS DHE ciphersuites). This is the digitalSignature flag

--- a/errors/X509_V_ERR_KEYUSAGE_NO_CRL_SIGN/ca.cfg
+++ b/errors/X509_V_ERR_KEYUSAGE_NO_CRL_SIGN/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_KEYUSAGE_NO_CRL_SIGN/endpoint.cfg
+++ b/errors/X509_V_ERR_KEYUSAGE_NO_CRL_SIGN/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used to sign data (needed
 # in TLS DHE ciphersuites). This is the digitalSignature flag

--- a/errors/X509_V_ERR_NO_EXPLICIT_POLICY/ca.cfg
+++ b/errors/X509_V_ERR_NO_EXPLICIT_POLICY/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_NO_EXPLICIT_POLICY/endpoint.cfg
+++ b/errors/X509_V_ERR_NO_EXPLICIT_POLICY/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used to sign data (needed
 # in TLS DHE ciphersuites). This is the digitalSignature flag

--- a/errors/X509_V_ERR_PATH_LENGTH_EXCEEDED/ca.cfg
+++ b/errors/X509_V_ERR_PATH_LENGTH_EXCEEDED/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_PATH_LENGTH_EXCEEDED/endpoint.cfg
+++ b/errors/X509_V_ERR_PATH_LENGTH_EXCEEDED/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used to sign data (needed
 # in TLS DHE ciphersuites). This is the digitalSignature flag

--- a/errors/X509_V_ERR_PATH_LENGTH_EXCEEDED/subca1.cfg
+++ b/errors/X509_V_ERR_PATH_LENGTH_EXCEEDED/subca1.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_PATH_LENGTH_EXCEEDED/subca2.cfg
+++ b/errors/X509_V_ERR_PATH_LENGTH_EXCEEDED/subca2.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_PERMITTED_VIOLATION/ca.cfg
+++ b/errors/X509_V_ERR_PERMITTED_VIOLATION/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_PERMITTED_VIOLATION/endpoint.cfg
+++ b/errors/X509_V_ERR_PERMITTED_VIOLATION/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used to sign data (needed
 # in TLS DHE ciphersuites). This is the digitalSignature flag

--- a/errors/X509_V_ERR_PROXY_CERTIFICATES_NOT_ALLOWED/ca.cfg
+++ b/errors/X509_V_ERR_PROXY_CERTIFICATES_NOT_ALLOWED/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_PROXY_CERTIFICATES_NOT_ALLOWED/endpoint.cfg
+++ b/errors/X509_V_ERR_PROXY_CERTIFICATES_NOT_ALLOWED/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used to sign data (needed
 # in TLS DHE ciphersuites). This is the digitalSignature flag

--- a/errors/X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN/ca.cfg
+++ b/errors/X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN/endpoint.cfg
+++ b/errors/X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used to sign data (needed
 # in TLS DHE ciphersuites). This is the digitalSignature flag

--- a/errors/X509_V_ERR_SUITE_B_INVALID_ALGORITHM/ca.cfg
+++ b/errors/X509_V_ERR_SUITE_B_INVALID_ALGORITHM/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_SUITE_B_INVALID_ALGORITHM/endpoint.cfg
+++ b/errors/X509_V_ERR_SUITE_B_INVALID_ALGORITHM/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used to sign data (needed
 # in TLS DHE ciphersuites). This is the digitalSignature flag

--- a/errors/X509_V_ERR_SUITE_B_INVALID_CURVE/ca.cfg
+++ b/errors/X509_V_ERR_SUITE_B_INVALID_CURVE/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_SUITE_B_INVALID_CURVE/endpoint.cfg
+++ b/errors/X509_V_ERR_SUITE_B_INVALID_CURVE/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used to sign data (needed
 # in TLS DHE ciphersuites). This is the digitalSignature flag

--- a/errors/X509_V_ERR_SUITE_B_INVALID_VERSION/ca.cfg
+++ b/errors/X509_V_ERR_SUITE_B_INVALID_VERSION/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_SUITE_B_INVALID_VERSION/endpoint.cfg
+++ b/errors/X509_V_ERR_SUITE_B_INVALID_VERSION/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used to sign data (needed
 # in TLS DHE ciphersuites). This is the digitalSignature flag

--- a/errors/X509_V_ERR_SUITE_B_LOS_NOT_ALLOWED/ca.cfg
+++ b/errors/X509_V_ERR_SUITE_B_LOS_NOT_ALLOWED/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_SUITE_B_LOS_NOT_ALLOWED/endpoint.cfg
+++ b/errors/X509_V_ERR_SUITE_B_LOS_NOT_ALLOWED/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used to sign data (needed
 # in TLS DHE ciphersuites). This is the digitalSignature flag

--- a/errors/X509_V_ERR_UNABLE_TO_GET_CRL/ca.cfg
+++ b/errors/X509_V_ERR_UNABLE_TO_GET_CRL/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_UNABLE_TO_GET_CRL/endpoint.cfg
+++ b/errors/X509_V_ERR_UNABLE_TO_GET_CRL/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used to sign data (needed
 # in TLS DHE ciphersuites). This is the digitalSignature flag

--- a/errors/X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT/ca.cfg
+++ b/errors/X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT/endpoint.cfg
+++ b/errors/X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used to sign data (needed
 # in TLS DHE ciphersuites). This is the digitalSignature flag

--- a/errors/X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT/subca.cfg
+++ b/errors/X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT/subca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY/ca.cfg
+++ b/errors/X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY/ca.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this is a CA certificate or not
 ca

--- a/errors/X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY/endpoint.cfg
+++ b/errors/X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used to sign data (needed
 # in TLS DHE ciphersuites). This is the digitalSignature flag

--- a/errors/X509_V_OK/endpoint.cfg
+++ b/errors/X509_V_OK/endpoint.cfg
@@ -12,7 +12,7 @@ unit = "Centre for Research on Cryptography and Security"
 
 # In how many days, counting from today, this certificate will expire.
 # Use -1 if there is no expiration date.
-expiration_days = 30
+expiration_days = 365
 
 # Whether this certificate will be used to sign data (needed
 # in TLS DHE ciphersuites). This is the digitalSignature flag


### PR DESCRIPTION
I've encountered an issue, where if the repository isn't built in more than a month, all certificates that could be downloaded are expired.

I'm fixing this issue by changing the expiration_days in all endpoint.cfgs from 30 to 365.