### PR TITLE
Fix zip archive generation by deleting old contents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ $(BUILD_ERRORINFO_PREFIX)/%.md: utils/web-cert-data.sh $$(wildcard $(ERRORS_PREF
 $(BUILD_CERTZIP_PREFIX)/%.zip: $(BUILD_CERTS_PREFIX)/% $$(wildcard $(BUILD_CERTS_PREFIX)/%/*)
 	@printf "Generating zip for %-62s" $(*F)
 	@mkdir -p $(BUILD_CERTZIP_PREFIX)
-	@cd $(BUILD_CERTS_PREFIX) && zip --quiet ../$@ $(*F)/*.crt $(*F)/*.crl
+	@cd $(BUILD_CERTS_PREFIX) && zip --filesync --quiet ../$@ $(*F)/*.crt $(*F)/*.crl
 	@printf "[ OK ]\n"
 
 web-local: web


### PR DESCRIPTION
The zip command is set up so that it only updates the existing archive by default.
This causes old files to still be present in the archive.

Adding the -FS switch should solve this problem.