### PR TITLE
Move a failing certificate chain into a new debugging directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 errors/*/_certs
 _certs
 
+# Debug files
+_debug
+
 # Automatically generated website files
 web/assets/certs
 web/_errors

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # Environment settiongs
 ERRORS_PREFIX=errors
 BUILD_CERTS_PREFIX=_certs
+DEBUG_PREFIX=_debug
 BUILD_ERRORINFO_PREFIX=web/_errors
 BUILD_CERTZIP_PREFIX=web/assets/certs
 VERBOSITY=">/dev/null 2>&1"
@@ -22,13 +23,15 @@ $(BUILD_CERTS_PREFIX)/%: $(ERRORS_PREFIX)/%/Makefile $(wildcard ($(ERRORS_PREFIX
 	@$(MAKE) --silent --directory=$(ERRORS_PREFIX)/$(@F) BUILD_DIR=$(CURDIR)/$@ VERBOSITY=$(VERBOSITY) generate-cert
 	@printf "[ OK ]\n"
 	@printf "Testing OpenSSL validation for %-50s" $(*F)
-	@utils/test-cert-validation.sh $(ERRORS_PREFIX)/$(@F) $(CURDIR)/$@
+	@utils/test-cert-validation.sh $(ERRORS_PREFIX)/$(@F) $(CURDIR)/$@ && [ $$? -eq 0 ] || \
+	( rm -rf $(DEBUG_PREFIX) && mv $@ $(DEBUG_PREFIX)/ && printf "## See the failing certificate chain in $(DEBUG_PREFIX).\n" && exit 1 )
 	@printf "[ OK ]\n"
 
 certs-clean:
 	rm -rf errors/*/_certs
 	rm -rf $(BUILD_CERTS_PREFIX)
-
+	rm -rf $(DEBUG_PREFIX)
+	
 # Web building targets
 
 WEB_ERRORINFO=$(addsuffix .md, $(addprefix $(BUILD_ERRORINFO_PREFIX)/,$(ERROR_CODES_DATA)) )


### PR DESCRIPTION
Solves #47.

This change ensures that when some test of chain validation fails, a debugging directory called _debug is created and the whole failing chain from _certs is moved there. When the build is run again unchanged, the process repeats, deleting the contents of _debug first.

It's not the cleanest solution, but it works. All requests for changes are welcome.