### PR TITLE
Watch out for changes in static certificate chains

### DIFF
--- a/errors/X509_V_ERR_CERT_SIGNATURE_FAILURE/Makefile
+++ b/errors/X509_V_ERR_CERT_SIGNATURE_FAILURE/Makefile
@@ -15,7 +15,8 @@ error-code:
 
 generate-cert: $(BUILD_DIR)/endpoint.crt
 
-$(BUILD_DIR)/endpoint.crt:
+STATIC_CERTS=$(wildcard *.crt)
+$(BUILD_DIR)/endpoint.crt: $(STATIC_CERTS)
 	cp *.crt $(BUILD_DIR)
 
 verify-openssl:

--- a/errors/X509_V_ERR_UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY/Makefile
+++ b/errors/X509_V_ERR_UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY/Makefile
@@ -16,7 +16,8 @@ error-code:
 
 generate-cert: $(BUILD_DIR)/endpoint.crt
 
-$(BUILD_DIR)/endpoint.crt:
+STATIC_CERTS=$(wildcard *.crt)
+$(BUILD_DIR)/endpoint.crt: $(STATIC_CERTS)
 	cp *.crt $(BUILD_DIR)
 
 verify-openssl:

--- a/errors/X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION/Makefile
+++ b/errors/X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION/Makefile
@@ -14,7 +14,8 @@ error-code:
 
 generate-cert: $(BUILD_DIR)/endpoint.crt
 
-$(BUILD_DIR)/endpoint.crt:
+STATIC_CERTS=$(wildcard *.crt)
+$(BUILD_DIR)/endpoint.crt: $(STATIC_CERTS)
 	cp *.crt $(BUILD_DIR)
 
 verify-openssl:


### PR DESCRIPTION
Currently, `make generate-cert` on static certificate chains doesn't depend on the .crt files themselves. Therefore, chains in `_certs` wouldn't get updated when the chains in `errors` get updated.

This PR should solve the problem.