### PR TITLE
Add pages with other libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ test: all $(ERRORS_ALL)
 # Test generated certificates for assigned errors
 $(ERRORS_FOLDER)/*/*.yml:
 	@printf "Testing certificates for %-70s" $(@D)/$(@F)
-	@if RES=`grep verify-cert $@ | wc -l` && [ $$RES -eq 0 ]; then printf "[ -- ]\n"; \
+	@if RES=`grep verify-expected $@ | wc -l` && [ $$RES -eq 0 ]; then printf "[ -- ]\n"; \
 		else utils/test-cert-validation.sh $(CERTS_BUILD_FOLDER) $@ && printf "[ OK ]\n"; fi
 
 # Web targets

--- a/_data/botan/CANNOT_ESTABLISH_TRUST.yml
+++ b/_data/botan/CANNOT_ESTABLISH_TRUST.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   botan cert_verify chain.crt
 verify-cert: X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN
+weight: 201

--- a/_data/botan/CANNOT_ESTABLISH_TRUST.yml
+++ b/_data/botan/CANNOT_ESTABLISH_TRUST.yml
@@ -5,6 +5,5 @@ docs: |
   Cannot establish trust
 verify-command: |
   botan cert_verify chain.crt
-
 verify-cert: X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT
 verify-cert: X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN

--- a/_data/botan/CANNOT_ESTABLISH_TRUST.yml
+++ b/_data/botan/CANNOT_ESTABLISH_TRUST.yml
@@ -6,3 +6,5 @@ docs: |
 verify-command: |
   botan cert_verify chain.crt
 
+verify-cert: X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT
+verify-cert: X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN

--- a/_data/botan/CANNOT_ESTABLISH_TRUST.yml
+++ b/_data/botan/CANNOT_ESTABLISH_TRUST.yml
@@ -5,5 +5,4 @@ docs: |
   Cannot establish trust
 verify-command: |
   botan cert_verify chain.crt
-verify-cert: X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT
 verify-cert: X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN

--- a/_data/botan/CA_CERT_NOT_FOR_CERT_ISSUER.yml
+++ b/_data/botan/CA_CERT_NOT_FOR_CERT_ISSUER.yml
@@ -5,5 +5,4 @@ docs: |
   CA certificate not allowed to issue certs
 verify-command: |
   botan cert_verify endpoint.crt subca.crt ca.crt 
-
 verify-cert: X509_V_ERR_INVALID_CA

--- a/_data/botan/CA_CERT_NOT_FOR_CERT_ISSUER.yml
+++ b/_data/botan/CA_CERT_NOT_FOR_CERT_ISSUER.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   botan cert_verify endpoint.crt subca.crt ca.crt 
 verify-cert: X509_V_ERR_INVALID_CA
+weight: 302

--- a/_data/botan/CA_CERT_NOT_FOR_CERT_ISSUER.yml
+++ b/_data/botan/CA_CERT_NOT_FOR_CERT_ISSUER.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   botan cert_verify endpoint.crt subca.crt ca.crt 
 
+verify-cert: X509_V_ERR_INVALID_CA

--- a/_data/botan/CA_CERT_NOT_FOR_CRL_ISSUER.yml
+++ b/_data/botan/CA_CERT_NOT_FOR_CRL_ISSUER.yml
@@ -3,3 +3,4 @@ slug: ca-cert-not-for-crl-issuer
 tags: [ usage ]
 docs: |
   CA certificate not allowed to issue CRLs
+weight: 504

--- a/_data/botan/CA_CERT_NOT_FOR_CRL_ISSUER.yml
+++ b/_data/botan/CA_CERT_NOT_FOR_CRL_ISSUER.yml
@@ -1,5 +1,5 @@
 error-code: CA_CERT_NOT_FOR_CRL_ISSUER
 slug: ca-cert-not-for-crl-issuer
-tags: [ uncategorized ] #TODO
+tags: [ usage ]
 docs: |
   CA certificate not allowed to issue CRLs

--- a/_data/botan/CERT_CHAIN_LOOP.yml
+++ b/_data/botan/CERT_CHAIN_LOOP.yml
@@ -1,5 +1,5 @@
 error-code: CERT_CHAIN_LOOP
 slug: cert-chain-loop
-tags: [ uncategorized ] #TODO
+tags: [ trust ] # same as openssl's path loop
 docs: |
   Loop in certificate chain

--- a/_data/botan/CERT_CHAIN_LOOP.yml
+++ b/_data/botan/CERT_CHAIN_LOOP.yml
@@ -3,3 +3,4 @@ slug: cert-chain-loop
 tags: [ trust ] # same as openssl's path loop
 docs: |
   Loop in certificate chain
+weight: 205

--- a/_data/botan/CERT_CHAIN_TOO_LONG.yml
+++ b/_data/botan/CERT_CHAIN_TOO_LONG.yml
@@ -1,8 +1,9 @@
 error-code: CERT_CHAIN_TOO_LONG
 slug: cert-chain-too-long
-tags: [ extension ]
+tags: [ trust ]
 docs: |
   Certificate chain too long
 verify-command: |
   botan cert_verify endpoint.crt subca1.crt subca2.crt ca.crt
 verify-cert: X509_V_ERR_PATH_LENGTH_EXCEEDED
+weight: 206

--- a/_data/botan/CERT_CHAIN_TOO_LONG.yml
+++ b/_data/botan/CERT_CHAIN_TOO_LONG.yml
@@ -5,5 +5,4 @@ docs: |
   Certificate chain too long
 verify-command: |
   botan cert_verify endpoint.crt subca1.crt subca2.crt ca.crt
-
 verify-cert: X509_V_ERR_PATH_LENGTH_EXCEEDED

--- a/_data/botan/CERT_CHAIN_TOO_LONG.yml
+++ b/_data/botan/CERT_CHAIN_TOO_LONG.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   botan cert_verify endpoint.crt subca1.crt subca2.crt ca.crt
 
+verify-cert: X509_V_ERR_PATH_LENGTH_EXCEEDED

--- a/_data/botan/CERT_HAS_EXPIRED.yml
+++ b/_data/botan/CERT_HAS_EXPIRED.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   botan cert_verify endpoint.crt ca.crt
 verify-cert: X509_V_ERR_CERT_HAS_EXPIRED
+weight: 102

--- a/_data/botan/CERT_HAS_EXPIRED.yml
+++ b/_data/botan/CERT_HAS_EXPIRED.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   botan cert_verify endpoint.crt ca.crt
 
+verify-cert: X509_V_ERR_CERT_HAS_EXPIRED

--- a/_data/botan/CERT_HAS_EXPIRED.yml
+++ b/_data/botan/CERT_HAS_EXPIRED.yml
@@ -5,5 +5,4 @@ docs: |
   Certificate has expired
 verify-command: |
   botan cert_verify endpoint.crt ca.crt
-
 verify-cert: X509_V_ERR_CERT_HAS_EXPIRED

--- a/_data/botan/CERT_ISSUER_NOT_FOUND.yml
+++ b/_data/botan/CERT_ISSUER_NOT_FOUND.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   botan cert_verify endpoint.crt
 verify-cert: X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY
+weight: 204

--- a/_data/botan/CERT_ISSUER_NOT_FOUND.yml
+++ b/_data/botan/CERT_ISSUER_NOT_FOUND.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   botan cert_verify endpoint.crt
 
+verify-cert: X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY

--- a/_data/botan/CERT_ISSUER_NOT_FOUND.yml
+++ b/_data/botan/CERT_ISSUER_NOT_FOUND.yml
@@ -5,5 +5,4 @@ docs: |
   Certificate issuer not found
 verify-command: |
   botan cert_verify endpoint.crt
-
 verify-cert: X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY

--- a/_data/botan/CERT_IS_REVOKED.yml
+++ b/_data/botan/CERT_IS_REVOKED.yml
@@ -3,3 +3,4 @@ slug: cert-is-revoked
 tags: [ time ]
 docs: |
   Certificate is revoked
+verify-cert: X509_V_ERR_CERT_REVOKED

--- a/_data/botan/CERT_IS_REVOKED.yml
+++ b/_data/botan/CERT_IS_REVOKED.yml
@@ -4,3 +4,4 @@ tags: [ time ]
 docs: |
   Certificate is revoked
 verify-cert: X509_V_ERR_CERT_REVOKED
+weight: 108

--- a/_data/botan/CERT_NAME_NOMATCH.yml
+++ b/_data/botan/CERT_NAME_NOMATCH.yml
@@ -1,5 +1,5 @@
 error-code: CERT_NAME_NOMATCH
 slug: cert-name-nomatch
-tags: [ uncategorized ] #TODO
+tags: [ name ]
 docs: |
   Certificate does not match provided name

--- a/_data/botan/CERT_NAME_NOMATCH.yml
+++ b/_data/botan/CERT_NAME_NOMATCH.yml
@@ -3,3 +3,5 @@ slug: cert-name-nomatch
 tags: [ name ]
 docs: |
   Certificate does not match provided name
+verify-cert: X509_V_ERR_HOSTNAME_MISMATCH
+weight: 401

--- a/_data/botan/CERT_NAME_NO_MATCH.yml
+++ b/_data/botan/CERT_NAME_NO_MATCH.yml
@@ -3,3 +3,4 @@ slug: cert-name-no-match
 tags: [ name ]
 docs: |
   Certificate does not match provided name
+verify-cert: X509_V_ERR_HOSTNAME_MISMATCH

--- a/_data/botan/CERT_NAME_NO_MATCH.yml
+++ b/_data/botan/CERT_NAME_NO_MATCH.yml
@@ -1,6 +1,0 @@
-error-code: CERT_NAME_NO_MATCH
-slug: cert-name-no-match
-tags: [ name ]
-docs: |
-  Certificate does not match provided name
-verify-cert: X509_V_ERR_HOSTNAME_MISMATCH

--- a/_data/botan/CERT_NOT_YET_VALID.yml
+++ b/_data/botan/CERT_NOT_YET_VALID.yml
@@ -5,5 +5,4 @@ docs: |
   Certificate is not yet valid
 verify-command: |
   botan cert_verify endpoint.crt ca.crt
-
 verify-cert: X509_V_ERR_CERT_NOT_YET_VALID

--- a/_data/botan/CERT_NOT_YET_VALID.yml
+++ b/_data/botan/CERT_NOT_YET_VALID.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   botan cert_verify endpoint.crt ca.crt
 verify-cert: X509_V_ERR_CERT_NOT_YET_VALID
+weight: 101

--- a/_data/botan/CERT_NOT_YET_VALID.yml
+++ b/_data/botan/CERT_NOT_YET_VALID.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   botan cert_verify endpoint.crt ca.crt
 
+verify-cert: X509_V_ERR_CERT_NOT_YET_VALID

--- a/_data/botan/CERT_PUBKEY_INVALID.yml
+++ b/_data/botan/CERT_PUBKEY_INVALID.yml
@@ -1,5 +1,5 @@
 error-code: CERT_PUBKEY_INVALID
 slug: cert-pubkey-invalid
-tags: [ uncategorized ] #TODO
+tags: [ trust ]
 docs: |
   Certificate public key invalid, no HTTP support compiled in

--- a/_data/botan/CERT_PUBKEY_INVALID.yml
+++ b/_data/botan/CERT_PUBKEY_INVALID.yml
@@ -3,3 +3,4 @@ slug: cert-pubkey-invalid
 tags: [ trust ]
 docs: |
   Certificate public key invalid, no HTTP support compiled in
+weight: 203

--- a/_data/botan/CERT_SERIAL_NEGATIVE.yml
+++ b/_data/botan/CERT_SERIAL_NEGATIVE.yml
@@ -1,5 +1,5 @@
 error-code: CERT_SERIAL_NEGATIVE
 slug: cert-serial-negative
-tags: [ uncategorized ] #TODO
+tags: [ format ]
 docs: |
   Certificate serial number is negative

--- a/_data/botan/CERT_SERIAL_NEGATIVE.yml
+++ b/_data/botan/CERT_SERIAL_NEGATIVE.yml
@@ -3,3 +3,4 @@ slug: cert-serial-negative
 tags: [ format ]
 docs: |
   Certificate serial number is negative
+weight: 703

--- a/_data/botan/CHAIN_LACKS_TRUST_ROOT.yml
+++ b/_data/botan/CHAIN_LACKS_TRUST_ROOT.yml
@@ -3,3 +3,4 @@ slug: chain-lacks-trust-root
 tags: [ trust ]
 docs: |
   Certificate chain does not end in a CA certificate
+weight: 202

--- a/_data/botan/CHAIN_LACKS_TRUST_ROOT.yml
+++ b/_data/botan/CHAIN_LACKS_TRUST_ROOT.yml
@@ -1,5 +1,5 @@
 error-code: CHAIN_LACKS_TRUST_ROOT
 slug: chain-lacks-trust-root
-tags: [ uncategorized ] #TODO
+tags: [ trust ]
 docs: |
   Certificate chain does not end in a CA certificate

--- a/_data/botan/CHAIN_NAME_MISMATCH.yml
+++ b/_data/botan/CHAIN_NAME_MISMATCH.yml
@@ -1,5 +1,5 @@
 error-code: CHAIN_NAME_MISMATCH
 slug: chain-name-mismatch
-tags: [ uncategorized ] #TODO
+tags: [ name ]
 docs: |
   Certificate issuer does not match subject of issuing cert

--- a/_data/botan/CHAIN_NAME_MISMATCH.yml
+++ b/_data/botan/CHAIN_NAME_MISMATCH.yml
@@ -3,3 +3,4 @@ slug: chain-name-mismatch
 tags: [ name ]
 docs: |
   Certificate issuer does not match subject of issuing cert
+weight: 402

--- a/_data/botan/CRL_BAD_SIGNATURE.yml
+++ b/_data/botan/CRL_BAD_SIGNATURE.yml
@@ -1,5 +1,5 @@
 error-code: CRL_BAD_SIGNATURE
 slug: crl-bad-signature
-tags: [ uncategorized ] #TODO
+tags: [ format ] #this error should match openssl's X509_V_ERR_CRL_SIGNATURE_FAILURE
 docs: |
   CRL bad signature

--- a/_data/botan/CRL_BAD_SIGNATURE.yml
+++ b/_data/botan/CRL_BAD_SIGNATURE.yml
@@ -3,3 +3,4 @@ slug: crl-bad-signature
 tags: [ format ] #this error should match openssl's X509_V_ERR_CRL_SIGNATURE_FAILURE
 docs: |
   CRL bad signature
+weight: 702

--- a/_data/botan/CRL_HAS_EXPIRED.yml
+++ b/_data/botan/CRL_HAS_EXPIRED.yml
@@ -1,5 +1,5 @@
 error-code: CRL_HAS_EXPIRED
 slug: crl-has-expired
-tags: [ uncategorized ] #TODO
+tags: [ time ]
 docs: |
   CRL has expired

--- a/_data/botan/CRL_HAS_EXPIRED.yml
+++ b/_data/botan/CRL_HAS_EXPIRED.yml
@@ -3,3 +3,4 @@ slug: crl-has-expired
 tags: [ time ]
 docs: |
   CRL has expired
+weight: 104

--- a/_data/botan/CRL_NOT_YET_VALID.yml
+++ b/_data/botan/CRL_NOT_YET_VALID.yml
@@ -3,3 +3,4 @@ slug: crl-not-yet-valid
 tags: [ time ]
 docs: |
   CRL response is not yet valid
+weight: 103

--- a/_data/botan/CRL_NOT_YET_VALID.yml
+++ b/_data/botan/CRL_NOT_YET_VALID.yml
@@ -1,5 +1,5 @@
 error-code: CRL_NOT_YET_VALID
 slug: crl-not-yet-valid
-tags: [ uncategorized ] #TODO
+tags: [ time ]
 docs: |
   CRL response is not yet valid

--- a/_data/botan/DN_TOO_LONG.yml
+++ b/_data/botan/DN_TOO_LONG.yml
@@ -3,3 +3,4 @@ slug: dn-too-long
 tags: [ name ]
 docs: |
   Distinguished name too long
+weight: 404

--- a/_data/botan/DN_TOO_LONG.yml
+++ b/_data/botan/DN_TOO_LONG.yml
@@ -1,5 +1,5 @@
 error-code: DN_TOO_LONG
 slug: dn-too-long
-tags: [ uncategorized ] #TODO
+tags: [ name ]
 docs: |
   Distinguished name too long

--- a/_data/botan/DUPLICATE_CERT_EXTENSION.yml
+++ b/_data/botan/DUPLICATE_CERT_EXTENSION.yml
@@ -3,3 +3,4 @@ slug: duplicate-cert-extension
 tags: [ extension ]
 docs: |
   Duplicate certificate extension encountered
+weight: 303

--- a/_data/botan/DUPLICATE_CERT_EXTENSION.yml
+++ b/_data/botan/DUPLICATE_CERT_EXTENSION.yml
@@ -1,5 +1,5 @@
 error-code: DUPLICATE_CERT_EXTENSION
 slug: duplicate-cert-extension
-tags: [ uncategorized ] #TODO
+tags: [ extension ]
 docs: |
   Duplicate certificate extension encountered

--- a/_data/botan/DUPLICATE_CERT_POLICY.yml
+++ b/_data/botan/DUPLICATE_CERT_POLICY.yml
@@ -3,3 +3,4 @@ slug: duplicate-cert-policy
 tags: [ usage ]
 docs: |
   Certificate contains duplicate policy
+weight: 503

--- a/_data/botan/DUPLICATE_CERT_POLICY.yml
+++ b/_data/botan/DUPLICATE_CERT_POLICY.yml
@@ -1,5 +1,5 @@
 error-code: DUPLICATE_CERT_POLICY
 slug: duplicate-cert-policy
-tags: [ uncategorized ] #TODO
+tags: [ usage ]
 docs: |
   Certificate contains duplicate policy

--- a/_data/botan/EXT_IN_V1_V2_CERT.yml
+++ b/_data/botan/EXT_IN_V1_V2_CERT.yml
@@ -1,5 +1,5 @@
 error-code: EXT_IN_V1_V2_CERT
 slug: ext-in-v1-v2-cert
-tags: [ uncategorized ] #TODO
+tags: [ extension ] #not really sure
 docs: |
   Encountered extension in certificate with version < 3

--- a/_data/botan/EXT_IN_V1_V2_CERT.yml
+++ b/_data/botan/EXT_IN_V1_V2_CERT.yml
@@ -3,3 +3,4 @@ slug: ext-in-v1-v2-cert
 tags: [ extension ] #not really sure
 docs: |
   Encountered extension in certificate with version < 3
+weight: 304

--- a/_data/botan/INVALID_USAGE.yml
+++ b/_data/botan/INVALID_USAGE.yml
@@ -1,5 +1,5 @@
 error-code: INVALID_USAGE
 slug: invalid-usage
-tags: [ uncategorized ] #TODO
+tags: [ usage ]
 docs: |
   Certificate does not allow the requested usage

--- a/_data/botan/INVALID_USAGE.yml
+++ b/_data/botan/INVALID_USAGE.yml
@@ -3,3 +3,4 @@ slug: invalid-usage
 tags: [ usage ]
 docs: |
   Certificate does not allow the requested usage
+weight: 501

--- a/_data/botan/NAME_CONSTRAINT_ERROR.yml
+++ b/_data/botan/NAME_CONSTRAINT_ERROR.yml
@@ -5,5 +5,4 @@ docs: |
   Certificate does not pass name constraint
 verify-command: |
   botan cert_verify endpoint.crt ca.crt
-
 verify-cert: X509_V_ERR_PERMITTED_VIOLATION

--- a/_data/botan/NAME_CONSTRAINT_ERROR.yml
+++ b/_data/botan/NAME_CONSTRAINT_ERROR.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   botan cert_verify endpoint.crt ca.crt
 
+verify-cert: X509_V_ERR_PERMITTED_VIOLATION

--- a/_data/botan/NAME_CONSTRAINT_ERROR.yml
+++ b/_data/botan/NAME_CONSTRAINT_ERROR.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   botan cert_verify endpoint.crt ca.crt
 verify-cert: X509_V_ERR_PERMITTED_VIOLATION
+weight: 403

--- a/_data/botan/NO_MATCHING_CRLDP.yml
+++ b/_data/botan/NO_MATCHING_CRLDP.yml
@@ -3,3 +3,4 @@ slug: no-matching-crldp
 tags: [ uncategorized ]
 docs: |
   No CRL with matching distribution point for certificate
+weight: 801

--- a/_data/botan/NO_MATCHING_CRLDP.yml
+++ b/_data/botan/NO_MATCHING_CRLDP.yml
@@ -1,5 +1,5 @@
 error-code: NO_MATCHING_CRLDP
 slug: no-matching-crldp
-tags: [ uncategorized ] #TODO
+tags: [ uncategorized ]
 docs: |
   No CRL with matching distribution point for certificate

--- a/_data/botan/NO_REVOCATION_DATA.yml
+++ b/_data/botan/NO_REVOCATION_DATA.yml
@@ -3,3 +3,4 @@ slug: no-revocation-data
 tags: [ trust ]
 docs: |
   No revocation data
+weight: 215

--- a/_data/botan/NO_REVOCATION_DATA.yml
+++ b/_data/botan/NO_REVOCATION_DATA.yml
@@ -1,5 +1,5 @@
 error-code: NO_REVOCATION_DATA
 slug: no-revocation-data
-tags: [ uncategorized ] #TODO
+tags: [ trust ]
 docs: |
   No revocation data

--- a/_data/botan/OCSP_BAD_STATUS.yml
+++ b/_data/botan/OCSP_BAD_STATUS.yml
@@ -3,3 +3,4 @@ slug: ocsp-bad-status
 tags: [ trust ]
 docs: |
   OCSP bad status
+weight: 209

--- a/_data/botan/OCSP_BAD_STATUS.yml
+++ b/_data/botan/OCSP_BAD_STATUS.yml
@@ -1,5 +1,5 @@
 error-code: OCSP_BAD_STATUS
 slug: ocsp-bad-status
-tags: [ uncategorized ] #TODO
+tags: [ trust ]
 docs: |
   OCSP bad status

--- a/_data/botan/OCSP_CERT_NOT_LISTED.yml
+++ b/_data/botan/OCSP_CERT_NOT_LISTED.yml
@@ -3,3 +3,4 @@ slug: ocsp-cert-not-listed
 tags: [ uncategorized ]
 docs: |
   OCSP cert not listed
+weight: 802

--- a/_data/botan/OCSP_CERT_NOT_LISTED.yml
+++ b/_data/botan/OCSP_CERT_NOT_LISTED.yml
@@ -1,5 +1,5 @@
 error-code: OCSP_CERT_NOT_LISTED
 slug: ocsp-cert-not-listed
-tags: [ uncategorized ] #TODO
+tags: [ uncategorized ]
 docs: |
   OCSP cert not listed

--- a/_data/botan/OCSP_HAS_EXPIRED.yml
+++ b/_data/botan/OCSP_HAS_EXPIRED.yml
@@ -3,3 +3,4 @@ slug: ocsp-has-expired
 tags: [ time ] #or trust?
 docs: |
   OCSP response has expired
+weight: 106

--- a/_data/botan/OCSP_HAS_EXPIRED.yml
+++ b/_data/botan/OCSP_HAS_EXPIRED.yml
@@ -1,5 +1,5 @@
 error-code: OCSP_HAS_EXPIRED
 slug: ocsp-has-expired
-tags: [ uncategorized ] #TODO
+tags: [ time ] #or trust?
 docs: |
   OCSP response has expired

--- a/_data/botan/OCSP_ISSUER_NOT_FOUND.yml
+++ b/_data/botan/OCSP_ISSUER_NOT_FOUND.yml
@@ -3,3 +3,4 @@ slug: ocsp-issuer-not-found
 tags: [ trust ]
 docs: |
   Unable to find certificate issusing OCSP response
+weight: 207

--- a/_data/botan/OCSP_ISSUER_NOT_FOUND.yml
+++ b/_data/botan/OCSP_ISSUER_NOT_FOUND.yml
@@ -1,5 +1,5 @@
 error-code: OCSP_ISSUER_NOT_FOUND
 slug: ocsp-issuer-not-found
-tags: [ uncategorized ] #TODO
+tags: [ trust ]
 docs: |
   Unable to find certificate issusing OCSP response

--- a/_data/botan/OCSP_IS_TOO_OLD.yml
+++ b/_data/botan/OCSP_IS_TOO_OLD.yml
@@ -3,3 +3,4 @@ slug: ocsp-is-too-old
 tags: [ time ] # or trust? also, why does this error sound similar to OCSP_HAS_EXPIRED
 docs: |
   OCSP response is too old
+weight: 107

--- a/_data/botan/OCSP_IS_TOO_OLD.yml
+++ b/_data/botan/OCSP_IS_TOO_OLD.yml
@@ -1,5 +1,5 @@
 error-code: OCSP_IS_TOO_OLD
 slug: ocsp-is-too-old
-tags: [ uncategorized ] #TODO
+tags: [ time ] # or trust? also, why does this error sound similar to OCSP_HAS_EXPIRED
 docs: |
   OCSP response is too old

--- a/_data/botan/OCSP_NOT_YET_VALID.yml
+++ b/_data/botan/OCSP_NOT_YET_VALID.yml
@@ -3,3 +3,4 @@ slug: ocsp-not-yet-valid
 tags: [ time ] #or trust ?
 docs: |
   OCSP is not yet valid
+weight: 105

--- a/_data/botan/OCSP_NOT_YET_VALID.yml
+++ b/_data/botan/OCSP_NOT_YET_VALID.yml
@@ -1,5 +1,5 @@
 error-code: OCSP_NOT_YET_VALID
 slug: ocsp-not-yet-valid
-tags: [ uncategorized ] #TODO
+tags: [ time ] #or trust ?
 docs: |
   OCSP is not yet valid

--- a/_data/botan/OCSP_NO_HTTP.yml
+++ b/_data/botan/OCSP_NO_HTTP.yml
@@ -1,5 +1,5 @@
 error-code: OCSP_NO_HTTP
 slug: ocsp-no-http
-tags: [ uncategorized ] #TODO
+tags: [ uncategorized ]
 docs: |
   OCSP requests not available

--- a/_data/botan/OCSP_NO_HTTP.yml
+++ b/_data/botan/OCSP_NO_HTTP.yml
@@ -3,3 +3,4 @@ slug: ocsp-no-http
 tags: [ uncategorized ]
 docs: |
   OCSP requests not available
+weight: 803

--- a/_data/botan/OCSP_NO_REVOCATION_URL.yml
+++ b/_data/botan/OCSP_NO_REVOCATION_URL.yml
@@ -1,5 +1,5 @@
 error-code: OCSP_NO_REVOCATION_URL
 slug: ocsp-no-revocation-url
-tags: [ uncategorized ] #TODO
+tags: [ uncategorized ]
 docs: |
   OCSP URL not available

--- a/_data/botan/OCSP_NO_REVOCATION_URL.yml
+++ b/_data/botan/OCSP_NO_REVOCATION_URL.yml
@@ -1,5 +1,6 @@
 error-code: OCSP_NO_REVOCATION_URL
 slug: ocsp-no-revocation-url
-tags: [ uncategorized ]
+tags: [ trust ]
 docs: |
   OCSP URL not available
+weight: 211

--- a/_data/botan/OCSP_RESPONSE_GOOD.yml
+++ b/_data/botan/OCSP_RESPONSE_GOOD.yml
@@ -3,3 +3,4 @@ slug: ocsp-response-good
 tags: [ uncategorized ]
 docs: |
   OCSP response accepted as affirming unrevoked status for certificate
+weight: 805

--- a/_data/botan/OCSP_RESPONSE_GOOD.yml
+++ b/_data/botan/OCSP_RESPONSE_GOOD.yml
@@ -1,5 +1,5 @@
 error-code: OCSP_RESPONSE_GOOD
 slug: ocsp-response-good
-tags: [ uncategorized ] #TODO
+tags: [ uncategorized ]
 docs: |
   OCSP response accepted as affirming unrevoked status for certificate

--- a/_data/botan/OCSP_RESPONSE_INVALID.yml
+++ b/_data/botan/OCSP_RESPONSE_INVALID.yml
@@ -1,5 +1,5 @@
 error-code: OCSP_RESPONSE_INVALID
 slug: ocsp-response-invalid
-tags: [ uncategorized ] #TODO
+tags: [ trust ]
 docs: |
   OCSP parsing valid

--- a/_data/botan/OCSP_RESPONSE_INVALID.yml
+++ b/_data/botan/OCSP_RESPONSE_INVALID.yml
@@ -3,3 +3,4 @@ slug: ocsp-response-invalid
 tags: [ trust ]
 docs: |
   OCSP parsing valid
+weight: 210

--- a/_data/botan/OCSP_RESPONSE_MISSING_KEYUSAGE.yml
+++ b/_data/botan/OCSP_RESPONSE_MISSING_KEYUSAGE.yml
@@ -1,5 +1,5 @@
 error-code: OCSP_RESPONSE_MISSING_KEYUSAGE
 slug: ocsp-response-missing-keyusage
-tags: [ uncategorized ] #TODO
+tags: [ usage ]
 docs: |
   OCSP issuer's keyusage prohibits OCSP

--- a/_data/botan/OCSP_RESPONSE_MISSING_KEYUSAGE.yml
+++ b/_data/botan/OCSP_RESPONSE_MISSING_KEYUSAGE.yml
@@ -3,3 +3,4 @@ slug: ocsp-response-missing-keyusage
 tags: [ usage ]
 docs: |
   OCSP issuer's keyusage prohibits OCSP
+weight: 505

--- a/_data/botan/OCSP_SERVER_NOT_AVAILABLE.yml
+++ b/_data/botan/OCSP_SERVER_NOT_AVAILABLE.yml
@@ -3,3 +3,4 @@ slug: ocsp-server-not-available
 tags: [ trust ]
 docs: |
   OCSP server not available
+weight: 213

--- a/_data/botan/OCSP_SERVER_NOT_AVAILABLE.yml
+++ b/_data/botan/OCSP_SERVER_NOT_AVAILABLE.yml
@@ -1,5 +1,5 @@
 error-code: OCSP_SERVER_NOT_AVAILABLE
 slug: ocsp-server-not-available
-tags: [ uncategorized ] #TODO
+tags: [ trust ]
 docs: |
   OCSP server not available

--- a/_data/botan/OCSP_SIGNATURE_ERROR.yml
+++ b/_data/botan/OCSP_SIGNATURE_ERROR.yml
@@ -1,5 +1,5 @@
 error-code: OCSP_SIGNATURE_ERROR
 slug: ocsp-signature-error
-tags: [ uncategorized ] #TODO
+tags: [ trust ]
 docs: |
   OCSP signature error

--- a/_data/botan/OCSP_SIGNATURE_ERROR.yml
+++ b/_data/botan/OCSP_SIGNATURE_ERROR.yml
@@ -3,3 +3,4 @@ slug: ocsp-signature-error
 tags: [ trust ]
 docs: |
   OCSP signature error
+weight: 208

--- a/_data/botan/OCSP_SIGNATURE_OK.yml
+++ b/_data/botan/OCSP_SIGNATURE_OK.yml
@@ -1,5 +1,5 @@
 error-code: OCSP_SIGNATURE_OK
 slug: ocsp-signature-ok
-tags: [ uncategorized ] #TODO
+tags: [ uncategorized ]
 docs: |
   Signature on OCSP response was found valid

--- a/_data/botan/OCSP_SIGNATURE_OK.yml
+++ b/_data/botan/OCSP_SIGNATURE_OK.yml
@@ -3,3 +3,4 @@ slug: ocsp-signature-ok
 tags: [ uncategorized ]
 docs: |
   Signature on OCSP response was found valid
+weight: 804

--- a/_data/botan/OSCP_NO_REVOCATION_URL.yml
+++ b/_data/botan/OSCP_NO_REVOCATION_URL.yml
@@ -1,5 +1,5 @@
 error-code: OSCP_NO_REVOCATION_URL
 slug: oscp-no-revocation-url
-tags: [ uncategorized ] #TODO
+tags: [ trust ]
 unused: |
   Deprecated due to a typo - will be removed in future major release

--- a/_data/botan/OSCP_NO_REVOCATION_URL.yml
+++ b/_data/botan/OSCP_NO_REVOCATION_URL.yml
@@ -3,3 +3,4 @@ slug: oscp-no-revocation-url
 tags: [ trust ]
 unused: |
   Deprecated due to a typo - will be removed in future major release
+weight: 212

--- a/_data/botan/OSCP_SERVER_NOT_AVAILABLE.yml
+++ b/_data/botan/OSCP_SERVER_NOT_AVAILABLE.yml
@@ -3,3 +3,4 @@ slug: oscp-server-not-available
 tags: [ trust ]
 unused: |
   Deprecated due to a typo - will be removed in future major release
+weight: 214

--- a/_data/botan/OSCP_SERVER_NOT_AVAILABLE.yml
+++ b/_data/botan/OSCP_SERVER_NOT_AVAILABLE.yml
@@ -1,5 +1,5 @@
 error-code: OSCP_SERVER_NOT_AVAILABLE
 slug: oscp-server-not-available
-tags: [ uncategorized ] #TODO
+tags: [ trust ]
 unused: |
   Deprecated due to a typo - will be removed in future major release

--- a/_data/botan/POLICY_ERROR.yml
+++ b/_data/botan/POLICY_ERROR.yml
@@ -1,5 +1,5 @@
 error-code: POLICY_ERROR
 slug: policy-error
-tags: [ uncategorized ] #TODO
+tags: [ usage ]
 docs: |
   Certificate policy error

--- a/_data/botan/POLICY_ERROR.yml
+++ b/_data/botan/POLICY_ERROR.yml
@@ -3,3 +3,4 @@ slug: policy-error
 tags: [ usage ]
 docs: |
   Certificate policy error
+weight: 502

--- a/_data/botan/SIGNATURE_ALGO_BAD_PARAMS.yml
+++ b/_data/botan/SIGNATURE_ALGO_BAD_PARAMS.yml
@@ -3,3 +3,4 @@ slug: signature-algo-bad-params
 tags: [ algorithm ]
 docs: |
   Certificate signature has invalid parameters
+weight: 603

--- a/_data/botan/SIGNATURE_ALGO_BAD_PARAMS.yml
+++ b/_data/botan/SIGNATURE_ALGO_BAD_PARAMS.yml
@@ -1,5 +1,5 @@
 error-code: SIGNATURE_ALGO_BAD_PARAMS
 slug: signature-algo-bad-params
-tags: [ uncategorized ] #TODO
+tags: [ algorithm ]
 docs: |
   Certificate signature has invalid parameters

--- a/_data/botan/SIGNATURE_ALGO_UNKNOWN.yml
+++ b/_data/botan/SIGNATURE_ALGO_UNKNOWN.yml
@@ -1,5 +1,5 @@
 error-code: SIGNATURE_ALGO_UNKNOWN
 slug: signature-algo-unknown
-tags: [ uncategorized ] #TODO
+tags: [ algorithm ]
 docs: |
   Certificate signed with unknown/unavailable algorithm

--- a/_data/botan/SIGNATURE_ALGO_UNKNOWN.yml
+++ b/_data/botan/SIGNATURE_ALGO_UNKNOWN.yml
@@ -3,3 +3,4 @@ slug: signature-algo-unknown
 tags: [ algorithm ]
 docs: |
   Certificate signed with unknown/unavailable algorithm
+weight: 602

--- a/_data/botan/SIGNATURE_ERROR.yml
+++ b/_data/botan/SIGNATURE_ERROR.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   botan cert_verify endpoint.crt ca.crt
 verify-cert: X509_V_ERR_CERT_SIGNATURE_FAILURE
+weight: 701

--- a/_data/botan/SIGNATURE_ERROR.yml
+++ b/_data/botan/SIGNATURE_ERROR.yml
@@ -5,5 +5,4 @@ docs: |
   Signature error
 verify-command: |
   botan cert_verify endpoint.crt ca.crt
-
 verify-cert: X509_V_ERR_CERT_SIGNATURE_FAILURE

--- a/_data/botan/SIGNATURE_ERROR.yml
+++ b/_data/botan/SIGNATURE_ERROR.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   botan cert_verify endpoint.crt ca.crt
 
+verify-cert: X509_V_ERR_CERT_SIGNATURE_FAILURE

--- a/_data/botan/SIGNATURE_METHOD_TOO_WEAK.yml
+++ b/_data/botan/SIGNATURE_METHOD_TOO_WEAK.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   botan cert_verify endpoint.crt ca.crt
 verify-cert: X509_V_ERR_CA_KEY_TOO_SMALL
+weight: 601

--- a/_data/botan/SIGNATURE_METHOD_TOO_WEAK.yml
+++ b/_data/botan/SIGNATURE_METHOD_TOO_WEAK.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   botan cert_verify endpoint.crt ca.crt
 
+verify-cert: X509_V_ERR_CA_KEY_TOO_SMALL

--- a/_data/botan/SIGNATURE_METHOD_TOO_WEAK.yml
+++ b/_data/botan/SIGNATURE_METHOD_TOO_WEAK.yml
@@ -5,5 +5,4 @@ docs: |
   Signature method too weak
 verify-command: |
   botan cert_verify endpoint.crt ca.crt
-
 verify-cert: X509_V_ERR_CA_KEY_TOO_SMALL

--- a/_data/botan/UNKNOWN_CRITICAL_EXTENSION.yml
+++ b/_data/botan/UNKNOWN_CRITICAL_EXTENSION.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   botan cert_verify endpoint.crt ca.crt
 verify-cert: X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION
+weight: 301

--- a/_data/botan/UNKNOWN_CRITICAL_EXTENSION.yml
+++ b/_data/botan/UNKNOWN_CRITICAL_EXTENSION.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   botan cert_verify endpoint.crt ca.crt
 
+verify-cert: X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION

--- a/_data/botan/UNKNOWN_CRITICAL_EXTENSION.yml
+++ b/_data/botan/UNKNOWN_CRITICAL_EXTENSION.yml
@@ -5,5 +5,4 @@ docs: |
   Unknown critical extension encountered
 verify-command: |
   botan cert_verify endpoint.crt ca.crt
-
 verify-cert: X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION

--- a/_data/botan/UNTRUSTED_HASH.yml
+++ b/_data/botan/UNTRUSTED_HASH.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   botan cert_verify endpoint.crt ca.crt
 verify-cert: X509_V_ERR_CA_MD_TOO_WEAK
+weight: 604

--- a/_data/botan/UNTRUSTED_HASH.yml
+++ b/_data/botan/UNTRUSTED_HASH.yml
@@ -5,5 +5,4 @@ docs: |
   Hash function used is considered too weak for security
 verify-command: |
   botan cert_verify endpoint.crt ca.crt
-
 verify-cert: X509_V_ERR_CA_MD_TOO_WEAK

--- a/_data/botan/UNTRUSTED_HASH.yml
+++ b/_data/botan/UNTRUSTED_HASH.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   botan cert_verify endpoint.crt ca.crt
 
+verify-cert: X509_V_ERR_CA_MD_TOO_WEAK

--- a/_data/botan/VALID_CRL_CHECKED.yml
+++ b/_data/botan/VALID_CRL_CHECKED.yml
@@ -1,5 +1,5 @@
 error-code: VALID_CRL_CHECKED
 slug: valid-crl-checked
-tags: [ uncategorized ] #TODO
+tags: [ uncategorized ]
 docs: |
   Valid CRL examined

--- a/_data/botan/VALID_CRL_CHECKED.yml
+++ b/_data/botan/VALID_CRL_CHECKED.yml
@@ -3,3 +3,4 @@ slug: valid-crl-checked
 tags: [ uncategorized ]
 docs: |
   Valid CRL examined
+weight: 806

--- a/_data/botan/VERIFIED.yml
+++ b/_data/botan/VERIFIED.yml
@@ -5,5 +5,4 @@ docs: |
   Verified
 verify-command: |
   botan cert_verify endpoint.crt ca.crt
-
 verify-cert: X509_V_OK

--- a/_data/botan/VERIFIED.yml
+++ b/_data/botan/VERIFIED.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   botan cert_verify endpoint.crt ca.crt
 
+verify-cert: X509_V_OK

--- a/_data/botan/VERIFIED.yml
+++ b/_data/botan/VERIFIED.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   botan cert_verify endpoint.crt ca.crt
 verify-cert: X509_V_OK
+weight: 807

--- a/_data/gnutls/GNUTLS_CERT_EXPIRED.yml
+++ b/_data/gnutls/GNUTLS_CERT_EXPIRED.yml
@@ -5,4 +5,4 @@ docs: |
   The certificate has expired.
 verify-command: |
   certtool --verify --load-ca-certificate ca.crt --infile endpoint.crt
-
+verify-cert: X509_V_ERR_CERT_HAS_EXPIRED

--- a/_data/gnutls/GNUTLS_CERT_EXPIRED.yml
+++ b/_data/gnutls/GNUTLS_CERT_EXPIRED.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   certtool --verify --load-ca-certificate ca.crt --infile endpoint.crt
 verify-cert: X509_V_ERR_CERT_HAS_EXPIRED
+weight: 102

--- a/_data/gnutls/GNUTLS_CERT_INSECURE_ALGORITHM.yml
+++ b/_data/gnutls/GNUTLS_CERT_INSECURE_ALGORITHM.yml
@@ -3,3 +3,4 @@ slug: gnutls-cert-insecure-algorithm
 tags: [ algorithm ]
 docs: |
   The certificate was signed using an insecure algorithm such as MD2 or MD5. These algorithms have been broken and should not be trusted.
+weight: 601

--- a/_data/gnutls/GNUTLS_CERT_INSECURE_ALGORITHM.yml
+++ b/_data/gnutls/GNUTLS_CERT_INSECURE_ALGORITHM.yml
@@ -1,5 +1,5 @@
 error-code: GNUTLS_CERT_INSECURE_ALGORITHM
 slug: gnutls-cert-insecure-algorithm
-tags: [ uncategorized ] #TODO
+tags: [ algorithm ]
 docs: |
   The certificate was signed using an insecure algorithm such as MD2 or MD5. These algorithms have been broken and should not be trusted.

--- a/_data/gnutls/GNUTLS_CERT_INVALID.yml
+++ b/_data/gnutls/GNUTLS_CERT_INVALID.yml
@@ -3,3 +3,4 @@ slug: gnutls-cert-invalid
 tags: [ trust ]
 docs: |
   The certificate is not signed by one of the known authorities or the signature is invalid (deprecated by the flags GNUTLS_CERT_SIGNATURE_FAILURE and GNUTLS_CERT_SIGNER_NOT_FOUND ).
+weight: 201

--- a/_data/gnutls/GNUTLS_CERT_INVALID.yml
+++ b/_data/gnutls/GNUTLS_CERT_INVALID.yml
@@ -1,5 +1,5 @@
 error-code: GNUTLS_CERT_INVALID
 slug: gnutls-cert-invalid
-tags: [ uncategorized ] #TODO
+tags: [ trust ]
 docs: |
   The certificate is not signed by one of the known authorities or the signature is invalid (deprecated by the flags GNUTLS_CERT_SIGNATURE_FAILURE and GNUTLS_CERT_SIGNER_NOT_FOUND ).

--- a/_data/gnutls/GNUTLS_CERT_INVALID_OCSP_STATUS.yml
+++ b/_data/gnutls/GNUTLS_CERT_INVALID_OCSP_STATUS.yml
@@ -1,5 +1,5 @@
 error-code: GNUTLS_CERT_INVALID_OCSP_STATUS
 slug: gnutls-cert-invalid-ocsp-status
-tags: [ uncategorized ] #TODO
+tags: [ trust ]
 docs: |
   The received OCSP status response is invalid.

--- a/_data/gnutls/GNUTLS_CERT_INVALID_OCSP_STATUS.yml
+++ b/_data/gnutls/GNUTLS_CERT_INVALID_OCSP_STATUS.yml
@@ -3,3 +3,4 @@ slug: gnutls-cert-invalid-ocsp-status
 tags: [ trust ]
 docs: |
   The received OCSP status response is invalid.
+weight: 204

--- a/_data/gnutls/GNUTLS_CERT_MISMATCH.yml
+++ b/_data/gnutls/GNUTLS_CERT_MISMATCH.yml
@@ -1,5 +1,5 @@
 error-code: GNUTLS_CERT_MISMATCH
 slug: gnutls-cert-mismatch
-tags: [ uncategorized ] #TODO
+tags: [ trust ] # not really sure
 docs: |
   The certificate presented isn’t the expected one (TOFU)

--- a/_data/gnutls/GNUTLS_CERT_MISMATCH.yml
+++ b/_data/gnutls/GNUTLS_CERT_MISMATCH.yml
@@ -3,3 +3,4 @@ slug: gnutls-cert-mismatch
 tags: [ trust ] # not really sure
 docs: |
   The certificate presented isn’t the expected one (TOFU)
+weight: 205

--- a/_data/gnutls/GNUTLS_CERT_MISSING_OCSP_STATUS.yml
+++ b/_data/gnutls/GNUTLS_CERT_MISSING_OCSP_STATUS.yml
@@ -1,5 +1,5 @@
 error-code: GNUTLS_CERT_MISSING_OCSP_STATUS
 slug: gnutls-cert-missing-ocsp-status
-tags: [ uncategorized ] #TODO
+tags: [ trust ]
 docs: |
   The certificate requires the server to send the certifiate status, but no status was received.

--- a/_data/gnutls/GNUTLS_CERT_MISSING_OCSP_STATUS.yml
+++ b/_data/gnutls/GNUTLS_CERT_MISSING_OCSP_STATUS.yml
@@ -3,3 +3,4 @@ slug: gnutls-cert-missing-ocsp-status
 tags: [ trust ]
 docs: |
   The certificate requires the server to send the certifiate status, but no status was received.
+weight: 203

--- a/_data/gnutls/GNUTLS_CERT_NOT_ACTIVATED.yml
+++ b/_data/gnutls/GNUTLS_CERT_NOT_ACTIVATED.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   certtool --verify --load-ca-certificate ca.crt --infile endpoint.crt
 verify-cert: X509_V_ERR_CERT_NOT_YET_VALID
+weight: 101

--- a/_data/gnutls/GNUTLS_CERT_NOT_ACTIVATED.yml
+++ b/_data/gnutls/GNUTLS_CERT_NOT_ACTIVATED.yml
@@ -5,4 +5,4 @@ docs: |
   The certificate is not yet activated.
 verify-command: |
   certtool --verify --load-ca-certificate ca.crt --infile endpoint.crt
-
+verify-cert: X509_V_ERR_CERT_NOT_YET_VALID

--- a/_data/gnutls/GNUTLS_CERT_PURPOSE_MISMATCH.yml
+++ b/_data/gnutls/GNUTLS_CERT_PURPOSE_MISMATCH.yml
@@ -5,4 +5,4 @@ docs: |
   The certificate or an intermediate does not match the intended purpose (extended key usage).
 verify-command: |
   certtool --verify --load-ca-certificate ca.crt --infile endpoint.crt --verify-purpose 1.3.6.1.5.5.7.3.1 
-
+verify-cert: X509_V_ERR_INVALID_PURPOSE

--- a/_data/gnutls/GNUTLS_CERT_PURPOSE_MISMATCH.yml
+++ b/_data/gnutls/GNUTLS_CERT_PURPOSE_MISMATCH.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   certtool --verify --load-ca-certificate ca.crt --infile endpoint.crt --verify-purpose 1.3.6.1.5.5.7.3.1 
 verify-cert: X509_V_ERR_INVALID_PURPOSE
+weight: 501

--- a/_data/gnutls/GNUTLS_CERT_REVOCATION_DATA_ISSUED_IN_FUTURE.yml
+++ b/_data/gnutls/GNUTLS_CERT_REVOCATION_DATA_ISSUED_IN_FUTURE.yml
@@ -5,4 +5,4 @@ docs: |
   The revocation data have a future issue date.
 verify-command: |
   certtool --load-ca-certificate ca.crt --infile ca.crl --verify-crl
-
+verify-cert: X509_V_ERR_CRL_NOT_YET_VALID

--- a/_data/gnutls/GNUTLS_CERT_REVOCATION_DATA_ISSUED_IN_FUTURE.yml
+++ b/_data/gnutls/GNUTLS_CERT_REVOCATION_DATA_ISSUED_IN_FUTURE.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   certtool --load-ca-certificate ca.crt --infile ca.crl --verify-crl
 verify-cert: X509_V_ERR_CRL_NOT_YET_VALID
+weight: 103

--- a/_data/gnutls/GNUTLS_CERT_REVOCATION_DATA_SUPERSEDED.yml
+++ b/_data/gnutls/GNUTLS_CERT_REVOCATION_DATA_SUPERSEDED.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   certtool --load-ca-certificate ca.crt --infile ca.crl --verify-crl
 verify-cert: X509_V_ERR_CRL_HAS_EXPIRED
+weight: 104

--- a/_data/gnutls/GNUTLS_CERT_REVOCATION_DATA_SUPERSEDED.yml
+++ b/_data/gnutls/GNUTLS_CERT_REVOCATION_DATA_SUPERSEDED.yml
@@ -5,4 +5,4 @@ docs: |
   The revocation data are old and have been superseded.
 verify-command: |
   certtool --load-ca-certificate ca.crt --infile ca.crl --verify-crl
-
+verify-cert: X509_V_ERR_CRL_HAS_EXPIRED

--- a/_data/gnutls/GNUTLS_CERT_REVOKED.yml
+++ b/_data/gnutls/GNUTLS_CERT_REVOKED.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   certtool --verify --load-ca-certificate ca.crt --infile endpoint.crt
 verify-cert: X509_V_ERR_CERT_REVOKED
+weight: 105

--- a/_data/gnutls/GNUTLS_CERT_REVOKED.yml
+++ b/_data/gnutls/GNUTLS_CERT_REVOKED.yml
@@ -5,4 +5,4 @@ docs: |
   Certificate is revoked by its authority. In X.509 this will be set only if CRLs are checked.
 verify-command: |
   certtool --verify --load-ca-certificate ca.crt --infile endpoint.crt
-
+verify-cert: X509_V_ERR_CERT_REVOKED

--- a/_data/gnutls/GNUTLS_CERT_SIGNATURE_FAILURE.yml
+++ b/_data/gnutls/GNUTLS_CERT_SIGNATURE_FAILURE.yml
@@ -5,4 +5,5 @@ docs: |
   The signature verification failed.
 verify-command: |
   certtool --verify --load-ca-certificate ca.crt --infile endpoint.crt
-
+verify-cert: X509_V_ERR_CERT_SIGNATURE_FAILURE
+verify-cert: X509_V_ERR_CRL_SIGNATURE_FAILURE

--- a/_data/gnutls/GNUTLS_CERT_SIGNATURE_FAILURE.yml
+++ b/_data/gnutls/GNUTLS_CERT_SIGNATURE_FAILURE.yml
@@ -6,4 +6,3 @@ docs: |
 verify-command: |
   certtool --verify --load-ca-certificate ca.crt --infile endpoint.crt
 verify-cert: X509_V_ERR_CERT_SIGNATURE_FAILURE
-verify-cert: X509_V_ERR_CRL_SIGNATURE_FAILURE

--- a/_data/gnutls/GNUTLS_CERT_SIGNATURE_FAILURE.yml
+++ b/_data/gnutls/GNUTLS_CERT_SIGNATURE_FAILURE.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   certtool --verify --load-ca-certificate ca.crt --infile endpoint.crt
 verify-cert: X509_V_ERR_CERT_SIGNATURE_FAILURE
+weight: 701

--- a/_data/gnutls/GNUTLS_CERT_SIGNER_CONSTRAINTS_FAILURE.yml
+++ b/_data/gnutls/GNUTLS_CERT_SIGNER_CONSTRAINTS_FAILURE.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   certtool --verify --load-ca-certificate ca.crt --infile endpoint.crt
 verify-cert: X509_V_ERR_PERMITTED_VIOLATION
+weight: 402

--- a/_data/gnutls/GNUTLS_CERT_SIGNER_CONSTRAINTS_FAILURE.yml
+++ b/_data/gnutls/GNUTLS_CERT_SIGNER_CONSTRAINTS_FAILURE.yml
@@ -6,5 +6,3 @@ docs: |
 verify-command: |
   certtool --verify --load-ca-certificate ca.crt --infile endpoint.crt
 verify-cert: X509_V_ERR_PERMITTED_VIOLATION
-verify-cert: X509_V_ERR_PATH_LENGTH_EXCEEDED
-verify-cert: X509_V_ERR_EXCLUDED_VIOLATION

--- a/_data/gnutls/GNUTLS_CERT_SIGNER_CONSTRAINTS_FAILURE.yml
+++ b/_data/gnutls/GNUTLS_CERT_SIGNER_CONSTRAINTS_FAILURE.yml
@@ -5,4 +5,6 @@ docs: |
   The certificate’s signer constraints were violated.
 verify-command: |
   certtool --verify --load-ca-certificate ca.crt --infile endpoint.crt
-
+verify-cert: X509_V_ERR_PERMITTED_VIOLATION
+verify-cert: X509_V_ERR_PATH_LENGTH_EXCEEDED
+verify-cert: X509_V_ERR_EXCLUDED_VIOLATION

--- a/_data/gnutls/GNUTLS_CERT_SIGNER_NOT_CA.yml
+++ b/_data/gnutls/GNUTLS_CERT_SIGNER_NOT_CA.yml
@@ -5,4 +5,4 @@ docs: |
   The certificate’s signer was not a CA. This may happen if this was a version 1 certificate, which is common with some CAs, or a version 3 certificate without the basic constrains extension.
 verify-command: |
   certtool --verify --load-ca-certificate ca.crt --infile chain.crt
-
+verify-cert: X509_V_ERR_INVALID_CA

--- a/_data/gnutls/GNUTLS_CERT_SIGNER_NOT_CA.yml
+++ b/_data/gnutls/GNUTLS_CERT_SIGNER_NOT_CA.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   certtool --verify --load-ca-certificate ca.crt --infile chain.crt
 verify-cert: X509_V_ERR_INVALID_CA
+weight: 302

--- a/_data/gnutls/GNUTLS_CERT_SIGNER_NOT_FOUND.yml
+++ b/_data/gnutls/GNUTLS_CERT_SIGNER_NOT_FOUND.yml
@@ -5,7 +5,6 @@ docs: |
   The certificate’s issuer is not known. This is the case if the issuer is not included in the trusted certificate list.
 verify-command: |
   certtool --verify --infile endpoint.crt
-
 verify-cert: X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT
 verify-cert: X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN
 verify-cert: X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY

--- a/_data/gnutls/GNUTLS_CERT_SIGNER_NOT_FOUND.yml
+++ b/_data/gnutls/GNUTLS_CERT_SIGNER_NOT_FOUND.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   certtool --verify --infile endpoint.crt
 verify-cert: X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY
+weight: 202

--- a/_data/gnutls/GNUTLS_CERT_SIGNER_NOT_FOUND.yml
+++ b/_data/gnutls/GNUTLS_CERT_SIGNER_NOT_FOUND.yml
@@ -6,3 +6,6 @@ docs: |
 verify-command: |
   certtool --verify --infile endpoint.crt
 
+verify-cert: X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT
+verify-cert: X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN
+verify-cert: X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY

--- a/_data/gnutls/GNUTLS_CERT_SIGNER_NOT_FOUND.yml
+++ b/_data/gnutls/GNUTLS_CERT_SIGNER_NOT_FOUND.yml
@@ -5,6 +5,4 @@ docs: |
   The certificate’s issuer is not known. This is the case if the issuer is not included in the trusted certificate list.
 verify-command: |
   certtool --verify --infile endpoint.crt
-verify-cert: X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT
-verify-cert: X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN
 verify-cert: X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY

--- a/_data/gnutls/GNUTLS_CERT_UNEXPECTED_OWNER.yml
+++ b/_data/gnutls/GNUTLS_CERT_UNEXPECTED_OWNER.yml
@@ -3,3 +3,4 @@ slug: gnutls-cert-unexpected-owner
 tags: [ name ]
 docs: |
   The owner is not the expected one.
+weight: 401

--- a/_data/gnutls/GNUTLS_CERT_UNEXPECTED_OWNER.yml
+++ b/_data/gnutls/GNUTLS_CERT_UNEXPECTED_OWNER.yml
@@ -1,5 +1,5 @@
 error-code: GNUTLS_CERT_UNEXPECTED_OWNER
 slug: gnutls-cert-unexpected-owner
-tags: [ uncategorized ] #TODO
+tags: [ name ]
 docs: |
   The owner is not the expected one.

--- a/_data/gnutls/GNUTLS_CERT_UNKNOWN_CRIT_EXTENSIONS.yml
+++ b/_data/gnutls/GNUTLS_CERT_UNKNOWN_CRIT_EXTENSIONS.yml
@@ -5,4 +5,4 @@ docs: |
   The certificate has extensions marked as critical which are not supported.
 verify-command: |
   certtool --verify --load-ca-certificate ca.crt --infile endpoint.crt
-
+verify-cert: X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION

--- a/_data/gnutls/GNUTLS_CERT_UNKNOWN_CRIT_EXTENSIONS.yml
+++ b/_data/gnutls/GNUTLS_CERT_UNKNOWN_CRIT_EXTENSIONS.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   certtool --verify --load-ca-certificate ca.crt --infile endpoint.crt
 verify-cert: X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION
+weight: 301

--- a/_data/mbed/MBEDTLS_X509_BADCERT_BAD_KEY.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_BAD_KEY.yml
@@ -5,6 +5,5 @@ docs: |
   The certificate is signed with an unacceptable key (eg bad curve, RSA too short).
 verify-command: |
   mbedtls/programs/x509/cert_app mode=file filename=endpoint.crt ca_file=ca.crt
-
 verify-cert: X509_V_ERR_CA_KEY_TOO_SMALL
 verify-cert: X509_V_ERR_EE_KEY_TOO_SMALL

--- a/_data/mbed/MBEDTLS_X509_BADCERT_BAD_KEY.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_BAD_KEY.yml
@@ -6,3 +6,5 @@ docs: |
 verify-command: |
   mbedtls/programs/x509/cert_app mode=file filename=endpoint.crt ca_file=ca.crt
 
+verify-cert: X509_V_ERR_CA_KEY_TOO_SMALL
+verify-cert: X509_V_ERR_EE_KEY_TOO_SMALL

--- a/_data/mbed/MBEDTLS_X509_BADCERT_BAD_KEY.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_BAD_KEY.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   mbedtls/programs/x509/cert_app mode=file filename=endpoint.crt ca_file=ca.crt
 verify-cert: X509_V_ERR_CA_KEY_TOO_SMALL
+weight: 601

--- a/_data/mbed/MBEDTLS_X509_BADCERT_BAD_KEY.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_BAD_KEY.yml
@@ -6,4 +6,3 @@ docs: |
 verify-command: |
   mbedtls/programs/x509/cert_app mode=file filename=endpoint.crt ca_file=ca.crt
 verify-cert: X509_V_ERR_CA_KEY_TOO_SMALL
-verify-cert: X509_V_ERR_EE_KEY_TOO_SMALL

--- a/_data/mbed/MBEDTLS_X509_BADCERT_BAD_MD.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_BAD_MD.yml
@@ -5,5 +5,4 @@ docs: |
   The certificate is signed with an unacceptable hash.
 verify-command: |
   mbedtls/programs/x509/cert_app mode=file filename=endpoint.crt ca_file=ca.crt
-
 verify-cert: X509_V_ERR_CA_MD_TOO_WEAK

--- a/_data/mbed/MBEDTLS_X509_BADCERT_BAD_MD.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_BAD_MD.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   mbedtls/programs/x509/cert_app mode=file filename=endpoint.crt ca_file=ca.crt
 
+verify-cert: X509_V_ERR_CA_MD_TOO_WEAK

--- a/_data/mbed/MBEDTLS_X509_BADCERT_BAD_MD.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_BAD_MD.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   mbedtls/programs/x509/cert_app mode=file filename=endpoint.crt ca_file=ca.crt
 verify-cert: X509_V_ERR_CA_MD_TOO_WEAK
+weight: 605

--- a/_data/mbed/MBEDTLS_X509_BADCERT_BAD_PK.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_BAD_PK.yml
@@ -1,5 +1,5 @@
 error-code: MBEDTLS_X509_BADCERT_BAD_PK
 slug: mbedtls-x509-badcert-bad-pk
-tags: [ uncategorized ] #TODO
+tags: [ algorithm ]
 docs: |
   The certificate is signed with an unacceptable PK alg (eg RSA vs ECDSA).

--- a/_data/mbed/MBEDTLS_X509_BADCERT_BAD_PK.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_BAD_PK.yml
@@ -3,3 +3,4 @@ slug: mbedtls-x509-badcert-bad-pk
 tags: [ algorithm ]
 docs: |
   The certificate is signed with an unacceptable PK alg (eg RSA vs ECDSA).
+weight: 603

--- a/_data/mbed/MBEDTLS_X509_BADCERT_CN_MISMATCH.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_CN_MISMATCH.yml
@@ -4,3 +4,4 @@ tags: [ name ]
 docs: |
   The certificate Common Name (CN) does not match with the expected CN
 verify-cert: X509_V_ERR_HOSTNAME_MISMATCH
+weight: 401

--- a/_data/mbed/MBEDTLS_X509_BADCERT_CN_MISMATCH.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_CN_MISMATCH.yml
@@ -3,3 +3,4 @@ slug: mbedtls-x509-badcert-cn-mismatch
 tags: [ name ]
 docs: |
   The certificate Common Name (CN) does not match with the expected CN
+verify-cert: X509_V_ERR_HOSTNAME_MISMATCH

--- a/_data/mbed/MBEDTLS_X509_BADCERT_EXPIRED.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_EXPIRED.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   mbedtls/programs/x509/cert_app mode=file filename=/endpoint.crt ca_file=/ca.crt
 
+verify-cert: X509_V_ERR_CERT_HAS_EXPIRED

--- a/_data/mbed/MBEDTLS_X509_BADCERT_EXPIRED.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_EXPIRED.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   mbedtls/programs/x509/cert_app mode=file filename=/endpoint.crt ca_file=/ca.crt
 verify-cert: X509_V_ERR_CERT_HAS_EXPIRED
+weight: 102

--- a/_data/mbed/MBEDTLS_X509_BADCERT_EXPIRED.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_EXPIRED.yml
@@ -5,5 +5,4 @@ docs: |
   The certificate validity has expired
 verify-command: |
   mbedtls/programs/x509/cert_app mode=file filename=/endpoint.crt ca_file=/ca.crt
-
 verify-cert: X509_V_ERR_CERT_HAS_EXPIRED

--- a/_data/mbed/MBEDTLS_X509_BADCERT_EXT_KEY_USAGE.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_EXT_KEY_USAGE.yml
@@ -1,5 +1,5 @@
 error-code: MBEDTLS_X509_BADCERT_EXT_KEY_USAGE
 slug: mbedtls-x509-badcert-ext-key-usage
-tags: [ uncategorized ] #TODO
+tags: [ usage ]
 docs: |
   Usage does not match the extendedKeyUsage extension.

--- a/_data/mbed/MBEDTLS_X509_BADCERT_EXT_KEY_USAGE.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_EXT_KEY_USAGE.yml
@@ -3,3 +3,4 @@ slug: mbedtls-x509-badcert-ext-key-usage
 tags: [ usage ]
 docs: |
   Usage does not match the extendedKeyUsage extension.
+weight: 503

--- a/_data/mbed/MBEDTLS_X509_BADCERT_FUTURE.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_FUTURE.yml
@@ -5,5 +5,4 @@ docs: |
   The certificate validity starts in the future
 verify-command: |
   mbedtls/programs/x509/cert_app mode=file filename=/endpoint.crt ca_file=/ca.crt
-
 verify-cert: X509_V_ERR_CERT_NOT_YET_VALID

--- a/_data/mbed/MBEDTLS_X509_BADCERT_FUTURE.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_FUTURE.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   mbedtls/programs/x509/cert_app mode=file filename=/endpoint.crt ca_file=/ca.crt
 
+verify-cert: X509_V_ERR_CERT_NOT_YET_VALID

--- a/_data/mbed/MBEDTLS_X509_BADCERT_FUTURE.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_FUTURE.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   mbedtls/programs/x509/cert_app mode=file filename=/endpoint.crt ca_file=/ca.crt
 verify-cert: X509_V_ERR_CERT_NOT_YET_VALID
+weight: 101

--- a/_data/mbed/MBEDTLS_X509_BADCERT_KEY_USAGE.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_KEY_USAGE.yml
@@ -3,3 +3,4 @@ slug: mbedtls-x509-badcert-key-usage
 tags: [ usage ]
 docs: |
   Usage does not match the keyUsage extension.
+weight: 502

--- a/_data/mbed/MBEDTLS_X509_BADCERT_KEY_USAGE.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_KEY_USAGE.yml
@@ -1,5 +1,5 @@
 error-code: MBEDTLS_X509_BADCERT_KEY_USAGE
 slug: mbedtls-x509-badcert-key-usage
-tags: [ uncategorized ] #TODO
+tags: [ usage ]
 docs: |
   Usage does not match the keyUsage extension.

--- a/_data/mbed/MBEDTLS_X509_BADCERT_MISSING.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_MISSING.yml
@@ -3,3 +3,4 @@ slug: mbedtls-x509-badcert-missing
 tags: [ uncategorized ]
 docs: |
   Certificate was missing.
+weight: 801

--- a/_data/mbed/MBEDTLS_X509_BADCERT_MISSING.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_MISSING.yml
@@ -1,5 +1,5 @@
 error-code: MBEDTLS_X509_BADCERT_MISSING
 slug: mbedtls-x509-badcert-missing
-tags: [ uncategorized ] #TODO
+tags: [ uncategorized ]
 docs: |
   Certificate was missing.

--- a/_data/mbed/MBEDTLS_X509_BADCERT_NOT_TRUSTED.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_NOT_TRUSTED.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   mbedtls/programs/x509/cert_app mode=file filename=endpoint.crt ca_file=ca.crt
 verify-cert: X509_V_ERR_CERT_SIGNATURE_FAILURE
+weight: 201

--- a/_data/mbed/MBEDTLS_X509_BADCERT_NOT_TRUSTED.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_NOT_TRUSTED.yml
@@ -5,11 +5,4 @@ docs: |
   The certificate is not correctly signed by the trusted CA
 verify-command: |
   mbedtls/programs/x509/cert_app mode=file filename=endpoint.crt ca_file=ca.crt
-verify-cert: X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT
-verify-cert: X509_V_ERR_PERMITTED_VIOLATION
-verify-cert: X509_V_ERR_PATH_LENGTH_EXCEEDED
 verify-cert: X509_V_ERR_CERT_SIGNATURE_FAILURE
-verify-cert: X509_V_ERR_EXCLUDED_VIOLATION
-verify-cert: X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN
-verify-cert: X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY
-verify-cert: X509_V_ERR_INVALID_CA

--- a/_data/mbed/MBEDTLS_X509_BADCERT_NOT_TRUSTED.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_NOT_TRUSTED.yml
@@ -5,7 +5,6 @@ docs: |
   The certificate is not correctly signed by the trusted CA
 verify-command: |
   mbedtls/programs/x509/cert_app mode=file filename=endpoint.crt ca_file=ca.crt
-
 verify-cert: X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT
 verify-cert: X509_V_ERR_PERMITTED_VIOLATION
 verify-cert: X509_V_ERR_PATH_LENGTH_EXCEEDED

--- a/_data/mbed/MBEDTLS_X509_BADCERT_NOT_TRUSTED.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_NOT_TRUSTED.yml
@@ -6,3 +6,11 @@ docs: |
 verify-command: |
   mbedtls/programs/x509/cert_app mode=file filename=endpoint.crt ca_file=ca.crt
 
+verify-cert: X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT
+verify-cert: X509_V_ERR_PERMITTED_VIOLATION
+verify-cert: X509_V_ERR_PATH_LENGTH_EXCEEDED
+verify-cert: X509_V_ERR_CERT_SIGNATURE_FAILURE
+verify-cert: X509_V_ERR_EXCLUDED_VIOLATION
+verify-cert: X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN
+verify-cert: X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY
+verify-cert: X509_V_ERR_INVALID_CA

--- a/_data/mbed/MBEDTLS_X509_BADCERT_NOT_TRUSTED.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_NOT_TRUSTED.yml
@@ -1,6 +1,6 @@
 error-code: MBEDTLS_X509_BADCERT_NOT_TRUSTED
 slug: mbedtls-x509-badcert-not-trusted
-tags: [ extension ]
+tags: [ trust ]
 docs: |
   The certificate is not correctly signed by the trusted CA
 verify-command: |

--- a/_data/mbed/MBEDTLS_X509_BADCERT_NS_CERT_TYPE.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_NS_CERT_TYPE.yml
@@ -1,5 +1,5 @@
 error-code: MBEDTLS_X509_BADCERT_NS_CERT_TYPE
 slug: mbedtls-x509-badcert-ns-cert-type
-tags: [ uncategorized ] #TODO
+tags: [ usage ]
 docs: |
   Usage does not match the nsCertType extension.

--- a/_data/mbed/MBEDTLS_X509_BADCERT_NS_CERT_TYPE.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_NS_CERT_TYPE.yml
@@ -3,3 +3,4 @@ slug: mbedtls-x509-badcert-ns-cert-type
 tags: [ usage ]
 docs: |
   Usage does not match the nsCertType extension.
+weight: 501

--- a/_data/mbed/MBEDTLS_X509_BADCERT_OTHER.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_OTHER.yml
@@ -3,3 +3,4 @@ slug: mbedtls-x509-badcert-other
 tags: [ uncategorized ]
 docs: |
   Other reason (can be used by verify callback)
+weight: 802

--- a/_data/mbed/MBEDTLS_X509_BADCERT_OTHER.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_OTHER.yml
@@ -1,5 +1,5 @@
 error-code: MBEDTLS_X509_BADCERT_OTHER
 slug: mbedtls-x509-badcert-other
-tags: [ uncategorized ] #TODO
+tags: [ uncategorized ]
 docs: |
   Other reason (can be used by verify callback)

--- a/_data/mbed/MBEDTLS_X509_BADCERT_REVOKED.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_REVOKED.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   mbedtls/programs/x509/cert_app mode=file filename=/endpoint.crt ca_file=/ca.crt crl_file=/ca.crl
 
+verify-cert: X509_V_ERR_CERT_REVOKED

--- a/_data/mbed/MBEDTLS_X509_BADCERT_REVOKED.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_REVOKED.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   mbedtls/programs/x509/cert_app mode=file filename=/endpoint.crt ca_file=/ca.crt crl_file=/ca.crl
 verify-cert: X509_V_ERR_CERT_REVOKED
+weight: 105

--- a/_data/mbed/MBEDTLS_X509_BADCERT_REVOKED.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_REVOKED.yml
@@ -5,5 +5,4 @@ docs: |
   The certificate has been revoked (is on a CRL)
 verify-command: |
   mbedtls/programs/x509/cert_app mode=file filename=/endpoint.crt ca_file=/ca.crt crl_file=/ca.crl
-
 verify-cert: X509_V_ERR_CERT_REVOKED

--- a/_data/mbed/MBEDTLS_X509_BADCERT_SKIP_VERIFY.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_SKIP_VERIFY.yml
@@ -1,5 +1,5 @@
 error-code: MBEDTLS_X509_BADCERT_SKIP_VERIFY
 slug: mbedtls-x509-badcert-skip-verify
-tags: [ uncategorized ] #TODO
+tags: [ uncategorized ]
 docs: |
   Certificate verification was skipped.

--- a/_data/mbed/MBEDTLS_X509_BADCERT_SKIP_VERIFY.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCERT_SKIP_VERIFY.yml
@@ -3,3 +3,4 @@ slug: mbedtls-x509-badcert-skip-verify
 tags: [ uncategorized ]
 docs: |
   Certificate verification was skipped.
+weight: 803

--- a/_data/mbed/MBEDTLS_X509_BADCRL_BAD_KEY.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCRL_BAD_KEY.yml
@@ -3,3 +3,4 @@ slug: mbedtls-x509-badcrl-bad-key
 tags: [ algorithm ]
 docs: |
   The CRL is signed with an unacceptable key (eg bad curve, RSA too short).
+weight: 602

--- a/_data/mbed/MBEDTLS_X509_BADCRL_BAD_KEY.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCRL_BAD_KEY.yml
@@ -1,5 +1,5 @@
 error-code: MBEDTLS_X509_BADCRL_BAD_KEY
 slug: mbedtls-x509-badcrl-bad-key
-tags: [ uncategorized ] #TODO
+tags: [ algorithm ]
 docs: |
   The CRL is signed with an unacceptable key (eg bad curve, RSA too short).

--- a/_data/mbed/MBEDTLS_X509_BADCRL_BAD_MD.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCRL_BAD_MD.yml
@@ -1,5 +1,5 @@
 error-code: MBEDTLS_X509_BADCRL_BAD_MD
 slug: mbedtls-x509-badcrl-bad-md
-tags: [ uncategorized ] #TODO
+tags: [ algorithm ] # or trust?
 docs: |
   The CRL is signed with an unacceptable hash.

--- a/_data/mbed/MBEDTLS_X509_BADCRL_BAD_MD.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCRL_BAD_MD.yml
@@ -3,3 +3,4 @@ slug: mbedtls-x509-badcrl-bad-md
 tags: [ algorithm ] # or trust?
 docs: |
   The CRL is signed with an unacceptable hash.
+weight: 606

--- a/_data/mbed/MBEDTLS_X509_BADCRL_BAD_PK.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCRL_BAD_PK.yml
@@ -1,5 +1,5 @@
 error-code: MBEDTLS_X509_BADCRL_BAD_PK
 slug: mbedtls-x509-badcrl-bad-pk
-tags: [ uncategorized ] #TODO
+tags: [ algorithm ]
 docs: |
   The CRL is signed with an unacceptable PK alg (eg RSA vs ECDSA).

--- a/_data/mbed/MBEDTLS_X509_BADCRL_BAD_PK.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCRL_BAD_PK.yml
@@ -3,3 +3,4 @@ slug: mbedtls-x509-badcrl-bad-pk
 tags: [ algorithm ]
 docs: |
   The CRL is signed with an unacceptable PK alg (eg RSA vs ECDSA).
+weight: 604

--- a/_data/mbed/MBEDTLS_X509_BADCRL_EXPIRED.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCRL_EXPIRED.yml
@@ -5,5 +5,4 @@ docs: |
   The CRL is expired
 verify-command: |
   mbedtls/programs/x509/cert_app mode=file filename=endpoint.crt ca_file=ca.crt crl_file=ca.crl
-
 verify-cert: X509_V_ERR_CRL_HAS_EXPIRED

--- a/_data/mbed/MBEDTLS_X509_BADCRL_EXPIRED.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCRL_EXPIRED.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   mbedtls/programs/x509/cert_app mode=file filename=endpoint.crt ca_file=ca.crt crl_file=ca.crl
 
+verify-cert: X509_V_ERR_CRL_HAS_EXPIRED

--- a/_data/mbed/MBEDTLS_X509_BADCRL_EXPIRED.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCRL_EXPIRED.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   mbedtls/programs/x509/cert_app mode=file filename=endpoint.crt ca_file=ca.crt crl_file=ca.crl
 verify-cert: X509_V_ERR_CRL_HAS_EXPIRED
+weight: 104

--- a/_data/mbed/MBEDTLS_X509_BADCRL_FUTURE.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCRL_FUTURE.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   mbedtls/programs/x509/cert_app mode=file filename=endpoint.crt ca_file=ca.crt crl_file=ca.crl
 verify-cert: X509_V_ERR_CRL_NOT_YET_VALID
+weight: 103

--- a/_data/mbed/MBEDTLS_X509_BADCRL_FUTURE.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCRL_FUTURE.yml
@@ -5,5 +5,4 @@ docs: |
   The CRL is from the future
 verify-command: |
   mbedtls/programs/x509/cert_app mode=file filename=endpoint.crt ca_file=ca.crt crl_file=ca.crl
-
 verify-cert: X509_V_ERR_CRL_NOT_YET_VALID

--- a/_data/mbed/MBEDTLS_X509_BADCRL_FUTURE.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCRL_FUTURE.yml
@@ -6,3 +6,4 @@ docs: |
 verify-command: |
   mbedtls/programs/x509/cert_app mode=file filename=endpoint.crt ca_file=ca.crt crl_file=ca.crl
 
+verify-cert: X509_V_ERR_CRL_NOT_YET_VALID

--- a/_data/mbed/MBEDTLS_X509_BADCRL_NOT_TRUSTED.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCRL_NOT_TRUSTED.yml
@@ -1,5 +1,5 @@
 error-code: MBEDTLS_X509_BADCRL_NOT_TRUSTED
 slug: mbedtls-x509-badcrl-not-trusted
-tags: [ uncategorized ] #TODO
+tags: [ trust ]
 docs: |
   The CRL is not correctly signed by the trusted CA.

--- a/_data/mbed/MBEDTLS_X509_BADCRL_NOT_TRUSTED.yml
+++ b/_data/mbed/MBEDTLS_X509_BADCRL_NOT_TRUSTED.yml
@@ -3,3 +3,4 @@ slug: mbedtls-x509-badcrl-not-trusted
 tags: [ trust ]
 docs: |
   The CRL is not correctly signed by the trusted CA.
+weight: 202

--- a/_data/openssl/X509_V_ERR_HOSTNAME_MISMATCH.yml
+++ b/_data/openssl/X509_V_ERR_HOSTNAME_MISMATCH.yml
@@ -3,7 +3,7 @@ slug: x509-v-err-hostname-mismatch
 tags: [ name ]
 docs: |
   Hostname mismatch.
-botan-code: CERT_NAME_NO_MATCH
+botan-code: CERT_NAME_NOMATCH
 mbed-code: MBEDTLS_X509_BADCERT_CN_MISMATCH
 weight: 401
 verify-cert: X509_V_ERR_HOSTNAME_MISMATCH

--- a/_data/openssl/X509_V_OK.yml
+++ b/_data/openssl/X509_V_OK.yml
@@ -3,7 +3,7 @@ slug: x509-v-ok
 tags: [ uncategorized ]
 docs: |
   The operation was successful.
-botan-code: OK
+botan-code: VERIFIED
 weight: 819
 verify-cert: X509_V_OK
 verify-command: |

--- a/_includes/about.html
+++ b/_includes/about.html
@@ -1,0 +1,10 @@
+<div class="section"><div class="container clearfix">
+    <h2 id="about">About the project</h2>
+    <div class="col-lg-3 col-md-4 col-6 float-right">
+        <a class="no-ext-link-icon" href="https://crocs.fi.muni.cz">
+            <img class="crocs" src="/assets/img/crocs.png" alt="CRoCS FI MU" title="CRoCS FI MU">
+        </a>
+    </div>
+    <p>The project is developed at the <a href="https://www.fi.muni.cz/research/crocs/">Centre for Research on Cryptography and Security (CRoCS)</a> at <a href="http://www.muni.cz/">Masaryk University</a>, Brno, Czech Republic by <a href="https://crocs.fi.muni.cz/people/mukrop">Martin Ukrop</a>, Pavol Žáčik, Eric Valčík with the help of Michaela Balážová and Matěj Grabovský. For more details, see the ReadMe file in <a href="{{ site.repo-url }}">{% include icon.html icon="github" %}the project repository</a> on GitHub.</p>
+    <p>The authors are grateful for the financial support by and <a href="https://research.redhat.com/">Red Hat Czech</a> and <a href="https://www.kiwi.com">Kiwi.com</a>.
+</div></div>

--- a/_includes/all_errors.html
+++ b/_includes/all_errors.html
@@ -1,0 +1,16 @@
+{% for category in site.data.errors %}
+
+<div id="{{ page.library }}" class="section"><div class="container" markdown="1">
+    <h2 id="{{ category.title | slugify }}">{{ category.title }}</h2>
+    <p>
+    {{ category.description }} <br/>
+    {{ category.links }}
+    </p>
+
+    {% assign errors = site.data[page.library] | where:"tags", category.tag | sort: 'weight' %}
+    {% for error in errors %}
+    {% include error_box.html page=error %}
+    {% endfor %}
+</div></div>
+
+{% endfor %}

--- a/_includes/all_errors.html
+++ b/_includes/all_errors.html
@@ -1,8 +1,9 @@
+
 {% for category in site.data.errors %}
 
 {% assign errors = site.data[page.library] | where:"tags", category.tag | sort: 'weight' %}
 {% unless errors.size == 0 %}
-    <div id="{{ page.library }}" class="section"><div class="container" markdown="1">
+    <div id="errors" class="section"><div class="container" markdown="1">
         <h2 id="{{ category.title | slugify }}">{{ category.title }}</h2>
         <p>
         {{ category.description }} <br/>
@@ -16,3 +17,4 @@
 {% endunless %}
 
 {% endfor %}
+

--- a/_includes/all_errors.html
+++ b/_includes/all_errors.html
@@ -1,16 +1,18 @@
 {% for category in site.data.errors %}
 
-<div id="{{ page.library }}" class="section"><div class="container" markdown="1">
-    <h2 id="{{ category.title | slugify }}">{{ category.title }}</h2>
-    <p>
-    {{ category.description }} <br/>
-    {{ category.links }}
-    </p>
+{% assign errors = site.data[page.library] | where:"tags", category.tag | sort: 'weight' %}
+{% unless errors.size == 0 %}
+    <div id="{{ page.library }}" class="section"><div class="container" markdown="1">
+        <h2 id="{{ category.title | slugify }}">{{ category.title }}</h2>
+        <p>
+        {{ category.description }} <br/>
+        {{ category.links }}
+        </p>
 
-    {% assign errors = site.data[page.library] | where:"tags", category.tag | sort: 'weight' %}
-    {% for error in errors %}
-    {% include error_box.html page=error %}
-    {% endfor %}
-</div></div>
+        {% for error in errors %}
+        {% include error_box.html page=error %}
+        {% endfor %}
+    </div></div>
+{% endunless %}
 
 {% endfor %}

--- a/_includes/error_box.html
+++ b/_includes/error_box.html
@@ -17,8 +17,12 @@
     {% if include.page.gnutls-code %}
         {% include icon.html icon="gnutls-book" float="float-right" %}
     {% endif %}
-    {% if include.page.error-code %}
+    {% if include.page.openssl-code %}
         {% include icon.html icon="openssl-book" float="float-right" %}
+    {% endif %}
+    {% if include.page.error-code %}
+        {% assign lib-book=page.library | append: "-book" %}
+        {% include icon.html icon=lib-book float="float-right" %}
     {% endif %}
 </div>
 <div class="collapse show" id="{{ include.page.slug }}">
@@ -43,9 +47,11 @@
         {% endif %}
         {% if include.page.error-code %}
             <h3>
-            {% include icon.html icon="openssl-book" %}
-            OpenSSL: {{ include.page.error-code | replace: "_", "_&shy;" }}
-            <span class="text-muted small">(<a class="color-reset" href="https://www.openssl.org/docs/man1.1.1/man1/openssl-verify.html">source</a>)</span>
+            {% assign lib-book=page.library | append: "-book" %}
+            {% include icon.html icon=lib-book %}
+            {% assign library=site.data.libraries | where: "name", page.library | first %}
+            {{ library.title }}: {{ include.page.error-code | replace: "_", "_&shy;" }}
+            <span class="text-muted small">(<a class="color-reset" href="{{ library.source }}">source</a>)</span>
             </h3>
             {% if include.page.docs %}
                 <p>{{ include.page.docs }}</p>

--- a/_includes/error_box.html
+++ b/_includes/error_box.html
@@ -32,7 +32,8 @@
         <p>Download <a href="/assets/certs-archives/{{ include.page.verify-cert }}.zip">{% include icon.html icon="zip" %}the certificate archive</a>. If you are interested in generating such certificate yourself, see the generating script for this case on <a href="{{ site.repo-url }}/tree/master/assets/certs/{{ include.page.verify-cert }}">{% include icon.html icon="github" %}the project GitHub</a>. To get the validation error, run the command as indicated below.</p>
         <ul>
             {% if include.page.verify-command %}
-            <li>OpenSSL: <code class="highlighter-rouge">{{ include.page.verify-command }}</code></li>
+            {% assign library=site.data.libraries | where: "name", page.library | first %}
+            <li>{{ library.title }}: <code class="highlighter-rouge">{{ include.page.verify-command }}</code></li>
             {% endif %}
 
             {% for library in site.data.libraries %}

--- a/_includes/error_box.html
+++ b/_includes/error_box.html
@@ -20,7 +20,7 @@
     {% if include.page.openssl-code %}
         {% include icon.html icon="openssl-book" float="float-right" %}
     {% endif %}
-    {% if include.page.error-code %}
+    {% if include.page.docs %}
         {% assign lib-book=page.library | append: "-book" %}
         {% include icon.html icon=lib-book float="float-right" %}
     {% endif %}

--- a/_includes/intro.html
+++ b/_includes/intro.html
@@ -1,0 +1,31 @@
+<div class="section"><div class="container">
+    <h1 id="home">{{ page.title }}</h1>
+    <div class="lead">
+    <p>Validating X.509 certificates correctly turns out to be pretty complicated (e.g. <a href="http://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf">Georgiev2012</a>, <a href="https://crocs.fi.muni.cz/papers/acsac2019">Ukrop2019</a>). Yet certificate validation is absolutely crucial for secure communication on the Internet (think <a href="https://en.wikipedia.org/wiki/Transport_Layer_Security">TLS</a>).</p>
+    <p>Our goal is to simplify the ecosystem by consolidating the errors and their documentation (similarly to <a href="https://blog.mozilla.org/blog/2017/10/18/mozilla-brings-microsoft-google-w3c-samsung-together-create-cross-browser-documentation-mdn/">web documentation</a>) and by explaining better what the validation errors mean.</p>
+    <p>For every error, we aim to provide an example certificate ({% include icon.html icon="certificate" %}), documentation from OpenSSL ({% include icon.html icon="openssl-book" %}, deprecated or unused denoted by {% include icon.html icon="unused" %}) and other TLS libraries ({% include icon.html icon="gnutls-book" %}, {% include icon.html icon="botan-book" %}, {% include icon.html icon="mbed-book" %}). In the future, we plan the possibility of reorganization based on the other libraries (currently, the web is organized by OpenSSL), adding the error frequencies based on IP-wide scans and elaborating on the consequences of individual errors.</p>
+    </div>
+    <div class="row intro">
+    <div class="col-md-4">
+        <div class="card card-body">
+            <h4>Multiple libraries</h4>
+            <p>Our consolidated taxonomy aims for eight most used TLS-enabled libraries. The main structure is based on <a href="https://www.openssl.org/">OpenSSL</a> as it is by far the most used library in the domain of TLS.</p>
+            <a href="https://docs.google.com/spreadsheets/d/1AYX02k49lBhrZ7fLoh5UsEaXU-OND27zX4LexnzVR-k/edit?usp=sharing" class="btn btn-primary">{% include icon.html icon="button-table" %} Error mapping</a>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card card-body">
+            <h4>Further details</h4>
+            <p>We extend the existing research on security, TLS and documentation design. Details are described in the frequently asked questions on a separate page.</p>
+            <a href="/faq" class="btn btn-primary">{% include icon.html icon="button-methodology" %} FAQ with details</a>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card card-body">
+            <h4>Feedback welcome!</h4>
+            <p>Like the project? Think it's useless? Found something not working? Please let us know, we are grateful for all feedback.</p>
+            <a href="{{ site.repo-url }}/issues/new?labels=bug&title=Bug+report&body=Please+describe+what+does+not+work..." class="btn btn-primary">{% include icon.html icon="button-bug" %} Bug report</a><a href="mailto:webmaster@x509errors.org" class="btn btn-primary">{% include icon.html icon="button-email" %} Email us!</a>
+        </div>
+    </div>
+    </div>
+</div></div>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -14,18 +14,22 @@
         <div class="collapse navbar-collapse" id="navbar">
             <ul class="navbar-nav ml-auto">
                 <li class="nav-item" data-toggle="collapse" data-target=".navbar-collapse.show">
-                    <a class="nav-link" href="{% if page.slug != 'index' %}/{% endif %}#home">Intro</a>
+                    <a class="nav-link" href="{% if page.library %}#home{% else %}/#home{% endif %}">Intro</a>
                 </li>
                 <li class="nav-item dropdown" data-toggle="collapse" data-target=".navbar-collapse.show">
-                    <a class="nav-link dropdown-toggle" id="dropdown01" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Errors</a>
+                    <a class="nav-link dropdown-toggle" id="dropdown01" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        {% if page.library %}{% if page.library == "mbed" %}mbedTLS{% else %}{{ page.library }}{% endif %}{% else %}Libraries{% endif %}
+                    </a>
                     <div class="dropdown-menu" aria-labelledby="dropdown01">
-                        {% for category in site.data.errors %}
-                          <a class="dropdown-item" href="{% if page.slug != 'index' %}/{% endif %}#{{ category.title | slugify }}">{{ category.title }}</a>
+                        {% for library in site.data.libraries %}
+                          <a class="dropdown-item" href=
+                          "{% if page.library != library.name %}/{% if library.name != 'openssl' %}{{ library.name }}{% endif %}{% endif %}#{{ library.name }}"
+                          >{{ library.title }}</a>
                         {% endfor %}
                     </div>
                 </li>
                 <li class="nav-item" data-toggle="collapse" data-target=".navbar-collapse.show">
-                    <a class="nav-link" href="{% if page.slug == 'index' %}/faq{% else %}#faq{% endif %}">FAQ</a>
+                    <a class="nav-link" href="{% if page.slug != 'faq' %}/faq{% else %}#faq{% endif %}">FAQ</a>
                 </li>
                 <li class="nav-item" data-toggle="collapse" data-target=".navbar-collapse.show">
                     <a class="nav-link" href="{% if page.slug != 'index' %}/{% endif %}#about">About</a>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -5,7 +5,7 @@
                 <span class="fas fa-fw fa-lg fa-certificate fa-stack-1x color-verydarkgrey"></span>
                 <span class="fas fa-fw fa-xs fa-check fa-stack-1x color-white"></span>
             </span>
-            {{ page.title-nav }}
+            {{ page.title }}
         </a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="Show/hide navigation">
             <span class="navbar-toggler-icon"></span>
@@ -17,14 +17,12 @@
                     <a class="nav-link" href="{% if page.library %}#home{% else %}/#home{% endif %}">Intro</a>
                 </li>
                 <li class="nav-item dropdown" data-toggle="collapse" data-target=".navbar-collapse.show">
-                    <a class="nav-link dropdown-toggle" id="dropdown01" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                        {% if page.library %}{% if page.library == "mbed" %}mbedTLS{% else %}{{ page.library }}{% endif %}{% else %}Libraries{% endif %}
-                    </a>
+                    <a class="nav-link dropdown-toggle" id="dropdown01" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Libraries</a>
                     <div class="dropdown-menu" aria-labelledby="dropdown01">
                         {% for library in site.data.libraries %}
                           <a class="dropdown-item" href=
-                          "{% if page.library != library.name %}/{% if library.name != 'openssl' %}{{ library.name }}{% endif %}{% endif %}#{{ library.name }}"
-                          >{{ library.title }}</a>
+                          "{% if page.library != library.name %}/{% if library.name != 'openssl' %}{{ library.name }}{% endif %}{% endif %}#errors">
+                          {{ library.title }}</a>
                         {% endfor %}
                     </div>
                 </li>

--- a/_pages/botan.html
+++ b/_pages/botan.html
@@ -1,7 +1,6 @@
 ---
 layout:     default
-title:      Usable X.509 errors
-title-nav:  Botan
+title:      "Usable X.509 errors: Botan"
 slug:       botan
 library:    botan
 ---

--- a/_pages/botan.html
+++ b/_pages/botan.html
@@ -1,0 +1,12 @@
+---
+layout:     default
+title:      Usable X.509 errors
+title-nav:  Botan
+slug:       botan
+library:    botan
+---
+{% include intro.html %}
+
+{% include all_errors.html %}
+
+{% include about.html %}

--- a/_pages/faq.md
+++ b/_pages/faq.md
@@ -1,7 +1,6 @@
 ---
 layout:     default
 title:      Frequently asked questions
-title-nav:  Project FAQ
 slug:       faq
 ---
 <div class="section"><div class="container" markdown="1">

--- a/_pages/gnutls.html
+++ b/_pages/gnutls.html
@@ -1,0 +1,12 @@
+---
+layout:     default
+title:      Usable X.509 errors
+title-nav:  GnuTLS
+slug:       gnutls
+library:    gnutls
+---
+{% include intro.html %}
+
+{% include all_errors.html %}
+
+{% include about.html %}

--- a/_pages/gnutls.html
+++ b/_pages/gnutls.html
@@ -1,7 +1,6 @@
 ---
 layout:     default
-title:      Usable X.509 errors
-title-nav:  GnuTLS
+title:      "Usable X.509 errors: GnuTLS"
 slug:       gnutls
 library:    gnutls
 ---

--- a/_pages/index.html
+++ b/_pages/index.html
@@ -1,65 +1,12 @@
 ---
 layout:     default
 title:      Usable X.509 errors
-title-nav:  Usable X.509 errors
+title-nav:  OpenSSL
 slug:       index
+library:    openssl
 ---
-<div class="section"><div class="container">
-    <h1 id="home">{{ page.title }}</h1>
-    <div class="lead">
-    <p>Validating X.509 certificates correctly turns out to be pretty complicated (e.g. <a href="http://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf">Georgiev2012</a>, <a href="https://crocs.fi.muni.cz/papers/acsac2019">Ukrop2019</a>). Yet certificate validation is absolutely crucial for secure communication on the Internet (think <a href="https://en.wikipedia.org/wiki/Transport_Layer_Security">TLS</a>).</p>
-    <p>Our goal is to simplify the ecosystem by consolidating the errors and their documentation (similarly to <a href="https://blog.mozilla.org/blog/2017/10/18/mozilla-brings-microsoft-google-w3c-samsung-together-create-cross-browser-documentation-mdn/">web documentation</a>) and by explaining better what the validation errors mean.</p>
-    <p>For every error, we aim to provide an example certificate ({% include icon.html icon="certificate" %}), documentation from OpenSSL ({% include icon.html icon="openssl-book" %}, deprecated or unused denoted by {% include icon.html icon="unused" %}) and other TLS libraries ({% include icon.html icon="gnutls-book" %}, {% include icon.html icon="botan-book" %}, {% include icon.html icon="mbed-book" %}). In the future, we plan the possibility of reorganization based on the other libraries (currently, the web is organized by OpenSSL), adding the error frequencies based on IP-wide scans and elaborating on the consequences of individual errors.</p>
-    </div>
-    <div class="row intro">
-    <div class="col-md-4">
-        <div class="card card-body">
-            <h4>Multiple libraries</h4>
-            <p>Our consolidated taxonomy aims for eight most used TLS-enabled libraries. The main structure is based on <a href="https://www.openssl.org/">OpenSSL</a> as it is by far the most used library in the domain of TLS.</p>
-            <a href="https://docs.google.com/spreadsheets/d/1AYX02k49lBhrZ7fLoh5UsEaXU-OND27zX4LexnzVR-k/edit?usp=sharing" class="btn btn-primary">{% include icon.html icon="button-table" %} Error mapping</a>
-        </div>
-    </div>
-    <div class="col-md-4">
-        <div class="card card-body">
-            <h4>Further details</h4>
-            <p>We extend the existing research on security, TLS and documentation design. Details are described in the frequently asked questions on a separate page.</p>
-            <a href="/faq" class="btn btn-primary">{% include icon.html icon="button-methodology" %} FAQ with details</a>
-        </div>
-    </div>
-    <div class="col-md-4">
-        <div class="card card-body">
-            <h4>Feedback welcome!</h4>
-            <p>Like the project? Think it's useless? Found something not working? Please let us know, we are grateful for all feedback.</p>
-            <a href="{{ site.repo-url }}/issues/new?labels=bug&title=Bug+report&body=Please+describe+what+does+not+work..." class="btn btn-primary">{% include icon.html icon="button-bug" %} Bug report</a><a href="mailto:webmaster@x509errors.org" class="btn btn-primary">{% include icon.html icon="button-email" %} Email us!</a>
-        </div>
-    </div>
-    </div>
-</div></div>
+{% include intro.html %}
 
-{% for category in site.data.errors %}
+{% include all_errors.html %}
 
-<div class="section"><div class="container" markdown="1">
-    <h2 id="{{ category.title | slugify }}">{{ category.title }}</h2>
-    <p>
-    {{ category.description }} <br/>
-    {{ category.links }}
-    </p>
-
-    {% assign errors = site.data.openssl | where:"tags",category.tag | sort: 'weight' %}
-    {% for error in errors %}
-    {% include error_box.html page=error %}
-    {% endfor %}
-</div></div>
-
-{% endfor %}
-
-<div class="section"><div class="container clearfix">
-    <h2 id="about">About the project</h2>
-    <div class="col-lg-3 col-md-4 col-6 float-right">
-        <a class="no-ext-link-icon" href="https://crocs.fi.muni.cz">
-            <img class="crocs" src="/assets/img/crocs.png" alt="CRoCS FI MU" title="CRoCS FI MU">
-        </a>
-    </div>
-    <p>The project is developed at the <a href="https://www.fi.muni.cz/research/crocs/">Centre for Research on Cryptography and Security (CRoCS)</a> at <a href="http://www.muni.cz/">Masaryk University</a>, Brno, Czech Republic by <a href="https://crocs.fi.muni.cz/people/mukrop">Martin Ukrop</a>, Pavol Žáčik, Eric Valčík with the help of Michaela Balážová and Matěj Grabovský. For more details, see the ReadMe file in <a href="{{ site.repo-url }}">{% include icon.html icon="github" %}the project repository</a> on GitHub.</p>
-    <p>The authors are grateful for the financial support by and <a href="https://research.redhat.com/">Red Hat Czech</a> and <a href="https://www.kiwi.com">Kiwi.com</a>.
-</div></div>
+{% include about.html %}

--- a/_pages/index.html
+++ b/_pages/index.html
@@ -1,7 +1,6 @@
 ---
 layout:     default
-title:      Usable X.509 errors
-title-nav:  OpenSSL
+title:      "Usable X.509 errors: OpenSSL"
 slug:       index
 library:    openssl
 ---

--- a/_pages/mbed.html
+++ b/_pages/mbed.html
@@ -1,0 +1,12 @@
+---
+layout:     default
+title:      Usable X.509 errors
+title-nav:  mbedTLS
+slug:       mbed
+library:    mbed
+---
+{% include intro.html %}
+
+{% include all_errors.html %}
+
+{% include about.html %}

--- a/_pages/mbed.html
+++ b/_pages/mbed.html
@@ -1,7 +1,6 @@
 ---
 layout:     default
-title:      Usable X.509 errors
-title-nav:  mbedTLS
+title:      "Usable X.509 errors: mbedTLS"
 slug:       mbed
 library:    mbed
 ---

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -134,7 +134,8 @@ blockquote {
 .color-reset { color: inherit !important; }
 
 .section {
-    padding-top: 3rem;
+    margin-top: -4rem;
+    padding-top: 7rem;
     padding-bottom: 3rem;
 }
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -134,8 +134,7 @@ blockquote {
 .color-reset { color: inherit !important; }
 
 .section {
-    margin-top: -4rem;
-    padding-top: 7rem;
+    padding-top: 3rem;
     padding-bottom: 3rem;
 }
 
@@ -144,6 +143,10 @@ blockquote {
         padding-top: 2rem;
         padding-bottom: 2rem;
     }
+}
+
+#errors {
+    scroll-margin-top: 2rem;
 }
 
 .section:nth-of-type(even) {


### PR DESCRIPTION
I've finally created GnuTLS', Botan's, and mbedTLS' own pages with errors. Right now the only things that I've changed are:

- I added three new pages with errors of the three mentioned libraries.
- In the navbar, I removed the errors dropdown and replaced it with links to the new library pages.
- And the title shown on the navbar when scrolled is no longer `Usable X.509 errors`, but changes to the name of the library.

I've done the sorting of the errors to categories by myself so please take a closer look at these changes, it is highly possible that some errors could have wrong category tags.
This PR is mergeable in my opinion.