### PR TITLE
Add docs-checker to the main branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,40 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Check docs
+
+on:
+  schedule:
+    - cron: '0 0 1,15 * *' # run on 1st and 15th every month
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup pytho
+      uses: actions/setup-python@v2
+      with:
+          python-version: '3.7'
+    - name: Download artifact
+      uses: valcikeric/download-base-artifact@master
+      with:
+        artifact: cached-docs
+        path: cached-docs
+        allow-fail: true
+      continue-on-error: true
+    - name: Install dependencies
+      run: |
+        pip install requests
+    - name: Run docs checker
+      run: |
+        python3 utils/docs-checker/libscheck.py
+    - name: Save cached docs
+      uses: actions/upload-artifact@v2
+      with:
+          name: cached-docs
+          path: cached-docs/
+      if: always()
+ 

--- a/utils/docs-checker/docs-urls.txt
+++ b/utils/docs-checker/docs-urls.txt
@@ -1,0 +1,16 @@
+# openSSL
+
+https://raw.githubusercontent.com/openssl/openssl/master/doc/man3/X509_STORE_CTX_get_error.pod
+https://raw.githubusercontent.com/openssl/openssl/master/doc/man1/openssl-verify.pod.in
+
+# mbedTLS
+
+https://raw.githubusercontent.com/ARMmbed/mbedtls/master/library/x509_crt.c
+
+# gnuTLS
+
+https://www.gnutls.org/manual/html_node/Verifying-X_002e509-certificate-paths.html
+
+# botan
+
+https://raw.githubusercontent.com/randombit/botan/master/src/lib/x509/cert_status.cpp

--- a/utils/docs-checker/libscheck.py
+++ b/utils/docs-checker/libscheck.py
@@ -1,0 +1,73 @@
+import requests
+import os
+import sys
+
+
+def create_dir():
+    try:
+        os.makedirs("cached-docs")
+    except FileExistsError:
+        pass
+
+
+def get_string(url):
+    """
+    Returns content from url in string format
+    """
+    try:
+        h = requests.get(url, allow_redirects=True)
+        return h.content.decode("utf-8")
+    except UnicodeDecodeError:
+        print("cant decode website content")
+        return None
+
+
+def write_to_path(file_path, string):
+    file = open(file_path, "w")
+    file.write(string)
+    file.close()
+
+
+def handle_urls(urls_file_path):
+    create_dir()
+    changed = 0
+    urls = open(urls_file_path, "r")
+    for url in urls:
+        url = url.strip("\n/ ")
+        if len(url) < 1 or url[0] == '#':
+            continue
+        file_name = os.path.basename(url)
+        if file_name == "":
+            continue
+        print("handling \u001b[36m%-40s" % (file_name + "\u001b[0m..."),
+              end=" ")
+        url_content = get_string(url)
+        if url_content is None or url_content == "404: Not Found":
+            return 1
+        try:
+            file = open("./cached-docs/" + file_name, "r")
+        except FileNotFoundError:
+            write_to_path("./cached-docs/" + file_name, url_content)
+            print("\u001b[34m[ NEW ]\u001b[0m")
+            continue
+        file_string = file.read()
+        if file_string != url_content:
+            print("\u001b[31m[ CHANGED ]\u001b[0m")
+            print("Running diff between cached file and new file...")
+            changed = 1
+            file.close()
+
+            write_to_path("./cached-docs/" + file_name + "_new", url_content)
+            os.system(
+                "diff ./cached-docs/%s ./cached-docs/%s_new"
+                % (file_name, file_name))
+            os.remove("./cached-docs/" + file_name + "_new")
+            write_to_path("./cached-docs/" + file_name, url_content)
+        else:
+            print("\u001b[32m[ OK ]\u001b[0m")
+            file.close()
+    return changed
+
+
+if __name__ == '__main__':
+    sys.exit(handle_urls("utils/docs-checker/docs-urls.txt"))


### PR DESCRIPTION
I've read that periodic (cron) GitHub actions can only run on the main branches, so I'm moving this utility to ours. Hopefully, now the docs-checker will be running as it is supposed to.

This means that we no longer need an extra branch for the docs-checker.