### PR TITLE
Add dependency and drop hardcoded locations in error-mapping script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ CERTS_BUILD_FOLDER=assets/certs-build
 CERTS_BUILD_DEBUG_FOLDER=assets/certs-build/_debug
 CERTS_ARCHIVES_FOLDER=assets/certs-archives
 MAPPING_FOLDER=_data/mapping
+MAPPING_DATA_FILE=_data/mapping.txt
 VERBOSITY=">/dev/null 2>&1"
 ERRORS_FOLDER=_data
 YML2CERT_FOLDER=utils/yml2cert
@@ -44,7 +45,7 @@ $(MAPPING_FOLDER)/%.yml: _data/mapping.txt
 	$(eval ERROR=$(basename $(notdir $@)))
 	$(eval LIBRARY=$(subst .yml,,$(patsubst %/,%,$(subst $(MAPPING_FOLDER)/,,$(dir $@)))))
 	@printf "Generating mapping for %-62s" "$(LIBRARY)/$(basename $(ERROR))"
-	@python3 utils/find_all_linked_errors.py $(LIBRARY) $(ERROR)
+	@python3 utils/find_all_linked_errors.py $(LIBRARY) $(ERROR) $(MAPPING_DATA_FILE) $(MAPPING_FOLDER)
 	@printf "[ OK ]\n"
 
 # Test web consistency

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ $(CERTS_ARCHIVES_FOLDER)/%.zip: $(CERTS_BUILD_FOLDER)/% $$(wildcard $(CERTS_BUIL
 	@printf "[ OK ]\n"
 
 # Generate mapping files
-$(MAPPING_FOLDER)/%.yml: _data/mapping.txt
+$(MAPPING_FOLDER)/%.yml: _data/mapping.txt $(MAPPING_DATA_FILE)
 	$(eval ERROR=$(basename $(notdir $@)))
 	$(eval LIBRARY=$(subst .yml,,$(patsubst %/,%,$(subst $(MAPPING_FOLDER)/,,$(dir $@)))))
 	@printf "Generating mapping for %-62s" "$(LIBRARY)/$(basename $(ERROR))"

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,9 @@ CERTS_IDS_ALL=$(notdir $(wildcard $(CERTS_FOLDER)/*))
 CERTS_BUILD_ALL=$(addprefix $(CERTS_BUILD_FOLDER)/,$(CERTS_IDS_ALL))
 CERTS_ARCHIVES_ALL=$(addsuffix .zip, $(addprefix $(CERTS_ARCHIVES_FOLDER)/, $(CERTS_IDS_ALL)) )
 ERRORS_ALL=$(wildcard $(ERRORS_FOLDER)/*/*.yml)
-ERRORS_WITH_LIBS_ALL=$(subst $(ERRORS_FOLDER),$(MAPPING_FOLDER),$(wildcard $(ERRORS_FOLDER)/*/*.yml))
+ERRORS_WITH_LIBS_ALL_MAPPING=$(subst $(ERRORS_FOLDER),$(MAPPING_FOLDER),$(wildcard $(ERRORS_FOLDER)/*/*.yml))
 
-all: $(YML2CERT_FOLDER)/yml2cert $(CERTS_BUILD_ALL) $(CERTS_ARCHIVES_ALL) $(ERRORS_WITH_LIBS_ALL)
+all: $(YML2CERT_FOLDER)/yml2cert $(CERTS_BUILD_ALL) $(CERTS_ARCHIVES_ALL) $(ERRORS_WITH_LIBS_ALL_MAPPING)
 
 $(YML2CERT_FOLDER)/yml2cert: $(YML2CERT_FOLDER)/*.go
 	@cd $(YML2CERT_FOLDER) && go build -o yml2cert *.go
@@ -41,7 +41,7 @@ $(CERTS_ARCHIVES_FOLDER)/%.zip: $(CERTS_BUILD_FOLDER)/% $$(wildcard $(CERTS_BUIL
 	@printf "[ OK ]\n"
 
 # Generate mapping files
-$(MAPPING_FOLDER)/%.yml: _data/mapping.txt $(MAPPING_DATA_FILE)
+$(MAPPING_FOLDER)/%.yml: $(MAPPING_DATA_FILE)
 	$(eval ERROR=$(basename $(notdir $@)))
 	$(eval LIBRARY=$(subst .yml,,$(patsubst %/,%,$(subst $(MAPPING_FOLDER)/,,$(dir $@)))))
 	@printf "Generating mapping for %-62s" "$(LIBRARY)/$(basename $(ERROR))"

--- a/utils/find_all_linked_errors.py
+++ b/utils/find_all_linked_errors.py
@@ -3,15 +3,15 @@ import re
 from typing import List, TextIO, Set
 from os import makedirs
 
-# usage: ./find_all_linked_errors.sh <library> <errors>
+# usage: ./find_all_linked_errors.sh <library> <errors> <mapping file> <mapping folder>
 #       - library: library, from which the errors is
 #       - error: error that we are trying to find linked errors to
+#       - mapping file: location of the file with all the mapping data
+#       - mapping folder: folder, where the generated error files should be in.
 # 
-# searches through _data/mapping.txt and finds all the linked errors.
-# right now, just focus on the ones that are equal, we can figure out
-# the other possibilites later
+# searches through <mapping file> and finds all the linked errors.
 #
-# creates file _data/mapping/<library>/<error>.yml filled like this:
+# creates file <mapping folder>/<library>/<error>.yml filled like this:
 #
 #       equal:
 #         openssl:
@@ -137,20 +137,20 @@ def append_file(errs: List[str], file: TextIO, category: str) -> None:
 
 # check input
 
-if len(sys.argv) != 3:
-    print("Usage: {} <library> <error>".format(sys.argv[0]))
+if len(sys.argv) != 5:
+    print("Usage: {} <library> <error> <mapping file> <mapping folder>".format(sys.argv[0]))
     sys.exit(1)
 
 # variables
 
 library = sys.argv[1]
 error = sys.argv[2]
+mapping_file_location = sys.argv[3]
+mapping_folder = sys.argv[4]
 
-mapping_file = open("_data/mapping.txt", "r")
+mapping_file = open(mapping_file_location, "r")
 mapping_data = mapping_file.read().split('\n')
 mapping_file.close()
-
-mapping_folder = "_data/mapping"
 
 output_file = mapping_folder + "/" + library + "/" + error + ".yml"
 

--- a/utils/find_all_linked_errors.py
+++ b/utils/find_all_linked_errors.py
@@ -1,7 +1,7 @@
 import sys
 import re
 from typing import List, TextIO, Set
-from os import makedirs
+from os import makedirs, remove, path
 
 # usage: ./find_all_linked_errors.sh <library> <errors> <mapping file> <mapping folder>
 #       - library: library, from which the errors is
@@ -158,11 +158,16 @@ output_file = mapping_folder + "/" + library + "/" + error + ".yml"
 
 makedirs(mapping_folder + "/" + library, exist_ok=True)
 
+# remove file if exists
+
+if path.exists(output_file):
+    remove(output_file)
+
+file = None
+
 # equal
 
 errors_equal = sorted(list(find_all_equal_errors(library, error, mapping_data)))
-
-file = None
 
 if errors_equal:
     if not file:


### PR DESCRIPTION
This should fix #89.
