### PR TITLE
Dismiss the necessity of Boost in Botan TLS client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ addons:
     - libgnutls28-dev
     - libbotan-2-dev
     - libmbedtls-dev
-    - libboost-program-options-dev
     - botan
 
 jdk:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To build TLS clients, the development versions of the following libraries are re
 
 * [OpenSSL](https://www.openssl.org/)
 * [GnuTLS](https://www.gnutls.org/) (also requires [libcurl](https://curl.se/libcurl/))
-* [Botan](https://botan.randombit.net/), preferentially version 2 (also requires [Boost Program options](https://www.boost.org/doc/libs/1_76_0/doc/html/program_options.html))
+* [Botan](https://botan.randombit.net/), preferentially version 2
 * [mBedTLS](https://tls.mbed.org/)
 * [OpenJDK](https://openjdk.java.net/)
 
@@ -35,9 +35,9 @@ On Ubuntu 20.04 LTS or Fedora 33 you can install them using the appropriate of t
 
 ```bash
 # Ubuntu 20.04
-apt install libssl-dev libgnutls28-dev botan libbotan-2-dev libmbedtls-dev libboost-program-options-dev openjdk-16-jdk libcurl4-openssl-dev
+apt install libssl-dev libgnutls28-dev botan libbotan-2-dev libmbedtls-dev openjdk-16-jdk libcurl4-openssl-dev
 # Fedora 33
-dnf install openssl-devel gnutls-devel botan2-devel mbedtls-devel java-latest-openjdk-devel boost-devel libcurl-devel
+dnf install openssl-devel gnutls-devel botan2-devel mbedtls-devel java-latest-openjdk-devel libcurl-devel
 ```
 
 The necessary Python packages are locally installed by running `make install`. Building the certificate chains requires the following Python packages: [setuptools](https://pypi.org/project/setuptools/), [asn1tools](https://github.com/eerimoq/asn1tools) and [pycryptodomex](https://pypi.org/project/pycryptodomex/). Running certificate validation further requires [shyaml](https://github.com/0k/shyaml), [yq](https://github.com/mikefarah/yq), [jq](https://stedolan.github.io/jq/) and [pyYAML](https://github.com/yaml/pyyaml) for parsing and manipulating YAML files.

--- a/validation/clients/botan/Makefile
+++ b/validation/clients/botan/Makefile
@@ -1,10 +1,10 @@
 CXX=g++
 CXXFLAGS=-Wall -Wextra -g -std=gnu++17 -I /usr/include/botan-2
-LDLIBS=-lbotan-2 -lboost_program_options
+LDLIBS=-lbotan-2
 
 all: build/client
 
-build/client: client.cpp
+build/client: client.cpp client.hpp
 	mkdir -p build
 	$(CXX) $(CXXFLAGS) -o build/client client.cpp $(LDLIBS)
 

--- a/validation/clients/botan/client.hpp
+++ b/validation/clients/botan/client.hpp
@@ -1,0 +1,34 @@
+#ifndef CLIENT_H
+#define CLIENT_H
+
+#include <stdbool.h>
+
+/* Buffer lengths for command line arguments */
+#define HOST_BUFFER_LENGTH 256
+#define PORT_BUFFER_LENGTH 16
+#define	PATH_BUFFER_LENGTH 4096
+
+#define PARSING_SUCCESS 0
+#define PARSING_ERROR 1
+
+/* Possible command line arguments */
+struct tls_options
+{
+	/* Determines whether we want to check revocation */
+	bool check_crl;
+	/* Determines whether we want to check OCSP online */
+	bool check_ocsp;
+	/* Determines whether we want to check stapled OCSP */
+	bool check_ocsp_staple;
+	/* Hostname to connect to */
+	char host[HOST_BUFFER_LENGTH];
+	/* Port number to use for the connection */
+	char port[PORT_BUFFER_LENGTH];
+	/* Path to a trusted root certificate */
+	char trust_anchor[PATH_BUFFER_LENGTH];
+};
+
+/* Function to parse the command line arguments */
+int parse_opts(int argc, char **argv, struct tls_options *opts);
+
+#endif


### PR DESCRIPTION
Boost is no longer needed, program options are processed using getopt. Solves #102.