### PR TITLE
Flatten the generated zip archives and include individual certs

### DIFF
--- a/validation/certs/Makefile
+++ b/validation/certs/Makefile
@@ -44,6 +44,9 @@ VRESULTS_FILE=$(VDIR)/vresults.yml
 # port counter
 PORT_CTR_FILE=$(VDIR)/.port
 
+# Chain splitting script
+SPLIT_SCRIPT=$(UTILS_DIR)/split_chain.py
+
 # All individual chain script directories
 CHAINS_ALL=$(notdir $(wildcard $(CHAINS_DIR)/*))
 # All individual chain build folders
@@ -92,7 +95,10 @@ $(VRESULTS_DIR)/%.yml: $(BUILD_DIR)/%/$(CHAIN_FILENAME)
 $(ARCHIVE_DIR)/%.zip: $(BUILD_DIR)/%/$(CHAIN_FILENAME)
 	@mkdir -p $(ARCHIVE_DIR)
 	@printf "Creating a zip archive: %-50s" $(basename $(@F))
-	@cd $(BUILD_DIR) && zip --filesync --quiet ../$@ $(*F)/*.pem $(ROOT)/$(ROOT).pem
+	@mkdir -p ./tmp/
+	@python3 $(SPLIT_SCRIPT) $< ./tmp/
+	@cd $(BUILD_DIR) && zip -j --filesync --quiet ../$@ ../tmp/* ../$< $(*F)/crl*.pem $(ROOT)/$(ROOT).pem
+	@rm -rf ./tmp/
 	@printf "[ OK ]\n"
 
 clean:

--- a/validation/certs/utils/split_chain.py
+++ b/validation/certs/utils/split_chain.py
@@ -1,0 +1,17 @@
+import sys
+
+BEGIN_STR = '-----BEGIN CERTIFICATE-----'
+
+with open(sys.argv[1], 'r') as f:
+    chain = f.read()
+
+tmp = chain.split(BEGIN_STR)
+tmp.pop(0)
+certs = list(map(lambda x: BEGIN_STR + x, tmp))
+
+with open(sys.argv[2] + 'endpoint.pem', 'w') as f:
+    f.write(certs[0])
+
+for i, cert in enumerate(certs[1:]):
+    with open(sys.argv[2] + 'intermediate' + str(i + 1) + '.pem', 'w') as f:
+        f.write(cert)


### PR DESCRIPTION
Currently, we export each chain as a single file `chain.pem` together with the root cert `root.pem`. This makes it hard to validate manually using command-line OpenSSL, since it only accepts a single cert per file.

This PR flattens the archive structure (no subdirectories as is the case now) and also exports each certificate separately.

An example archive may look like this:
- EXPIRED
      - chain.pem (contains endpoint and two intermediate CA certs)
      - root.pem
      - endpoint.pem
      - intermediate1.pem
      - intermediate2.pem

Solves #104.