### PR TITLE
Add pip3 package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
     - libbotan-2-dev
     - libmbedtls-dev
     - botan
+    - python3-pip
 
 jdk:
   - openjdk16


### PR DESCRIPTION
For some reason, pip3 stopped working and only works when installed using addons. 