### PR TITLE
Fix various links

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ apt install libssl-dev libgnutls28-dev botan libbotan-2-dev libmbedtls-dev openj
 dnf install openssl-devel gnutls-devel botan2-devel mbedtls-devel java-latest-openjdk-devel libcurl-devel
 ```
 
-The necessary Python packages are locally installed by running `make install`. Building the certificate chains requires the following Python packages: [setuptools](https://pypi.org/project/setuptools/), [asn1tools](https://github.com/eerimoq/asn1tools) and [pycryptodomex](https://pypi.org/project/pycryptodomex/). Running certificate validation further requires [shyaml](https://github.com/0k/shyaml), [yq](https://github.com/mikefarah/yq), [jq](https://stedolan.github.io/jq/) and [pyYAML](https://github.com/yaml/pyyaml) for parsing and manipulating YAML files.
+The necessary Python packages are locally installed by running `make install`. Building the certificate chains requires the following Python packages: [setuptools](https://pypi.org/project/setuptools/), [asn1tools](https://github.com/eerimoq/asn1tools) and [pycryptodomex](https://pypi.org/project/pycryptodomex/). Running certificate validation further requires [shyaml](https://github.com/0k/shyaml), [yq](https://kislyuk.github.io/yq/), [jq](https://stedolan.github.io/jq/) and [pyYAML](https://github.com/yaml/pyyaml) for parsing and manipulating YAML files.
 
 The website is build using [Jekyll](https://jekyllrb.com/). To develop locally, install Jekyll (e.g. according to [this guide](https://help.github.com/en/articles/setting-up-your-github-pages-site-locally-with-jekyll). Then run `make local` and see the website served at `localhost:4000`.
 

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 title: Usable X.509 errors
 description: Let's make the validation of TLS certificates usable.
 author: Centre for Research on Cryptography and Security, Masaryk University, Czechia
-url: https://x509errors.cz
+url: https://x509errors.org
 repo-url: https://github.com/crocs-muni/usable-cert-validation
 email: webmaster@x509errors.org
 

--- a/_data/libraries.yml
+++ b/_data/libraries.yml
@@ -16,7 +16,7 @@
 - name: mbedtls
   title: Mbed TLS
   docs-source: https://tls.mbed.org/api/group__x509__module.html
-  message-source: https://github.com/ARMmbed/mbedtls/blob/development/library/error.c
+  message-source: https://github.com/ARMmbed/mbedtls/blob/development/include/mbedtls/x509_crt.h
 
 - name: openjdk
   title: OpenJDK

--- a/_guides/openssl.md
+++ b/_guides/openssl.md
@@ -146,7 +146,7 @@ if (SSL_CTX_load_verify_locations(ctx, "trusted_ca.pem", "trusted_dir") != 1) {
 {:.text-success}
 ## Optional: Custom certificate validation settings
 
-Optionally, you may want to put additional constraints on certificate validation. OpenSSL allows for this by modifying the `verify params` structure. In this example, we enforce strict certificate validation and put requirements on the IP address contained in the _Subject Alternative Name_ extension of the server certificate. All possible settings and flags can be found in the original [documentation](https://www.openssl.org/docs/man1.1.0/man3/X509_VERIFY_PARAM_set_flags.html)
+Optionally, you may want to put additional constraints on certificate validation. OpenSSL allows for this by modifying the `verify params` structure. In this example, we enforce strict certificate validation and put requirements on the IP address contained in the _Subject Alternative Name_ extension of the server certificate. All possible settings and flags can be found in the original [documentation](https://www.openssl.org/docs/manmaster/man3/X509_VERIFY_PARAM_set_flags.html)
 
 ```c
 #include <openssl/x509.h>


### PR DESCRIPTION
Resolves #124.

Fixed:
- A link to wrong yq package, as pointed out by @shoracek. Thanks.
- Deprecated link to MbedTLS source code (the library changed structure).
- Wrong link to OpenSSL docs (linking version 1.1.0 instead of master).
- Wrong top-level-domain of our website (.cz -> .org).