### PR TITLE
gnutls.md function typo fixed

### DIFF
--- a/_guides/gnutls.md
+++ b/_guides/gnutls.md
@@ -266,7 +266,7 @@ If certificate validation fails, `gnutls_handshake()` will always fail with the 
 unsigned status = gnutls_session_get_verify_cert_status(session);
 
 /* Retrieve the certificate type. */
-gnutls_certificate_type_t cert_type = gnutls_certificate_type_get2(session);
+gnutls_certificate_type_t cert_type = gnutls_certificate_type_get(session);
 
 /* Prepare a buffer for the error message, fill it, and print the message to the standard error output. */
 gnutls_datum_t out = {0};


### PR DESCRIPTION
On the x509errors website, under the "guides" section for gnutls, there is incorrect usage of gnutls_certificate_type_get2() function. According to the documentation, the function gnutls_certificate_type_get() should be used instead, without the 2.