### PR TITLE
Fix issues with Python TLS server

### DIFF
--- a/validation/certs/Makefile
+++ b/validation/certs/Makefile
@@ -43,6 +43,8 @@ VRESULTS_DIR=$(VDIR)/vresults
 VRESULTS_FILE=$(VDIR)/vresults.yml
 # port counter
 PORT_CTR_FILE=$(VDIR)/.port
+# Python TLS server
+PYTHON_SERVER=$(SERVERS_DIR)/server.py
 
 # All individual chain script directories
 CHAINS_ALL=$(notdir $(wildcard $(CHAINS_DIR)/*))
@@ -77,7 +79,7 @@ $(BUILD_DIR)/%/$(CHAIN_FILENAME): $(ROOT_KEY_FILE) $(CHAINS_DIR)/%/$(GENERATE).p
 	@printf "[ OK ]\n"
 
 # After building the chain, we run the validation script on it
-$(VRESULTS_DIR)/%.yml: $(BUILD_DIR)/%/$(CHAIN_FILENAME)
+$(VRESULTS_DIR)/%.yml: $(BUILD_DIR)/%/$(CHAIN_FILENAME) $(PYTHON_SERVER)
 	@mkdir -p $(VRESULTS_DIR)
 	@printf "Validating chain: %-50s" $(basename $(@F))
 	@$(VSCRIPT) --certs_dir $(CURDIR) \

--- a/validation/certs/scripts/chains/duplicate-bc-extension/vconfig.yml
+++ b/validation/certs/scripts/chains/duplicate-bc-extension/vconfig.yml
@@ -1,6 +1,5 @@
 servers:
-  main:
-    which: "python"
+  main: {}
 
 verify:
   openssl:


### PR DESCRIPTION
I updated the Python TLS server according to the [most recent example](https://docs.python.org/3/library/asyncio-stream.html#tcp-echo-server-using-streams) from Python docs. This fixes the issue of the server crashing on some certificate chains.

The same server also started failing on the `duplicate-bc-extension` chain (possibly a new check added to the Python ssl library), so I changed the configuration of the chain such that it is handled by the Botan server (which is the default option).
 